### PR TITLE
chore: prepare 0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes will be documented in this file. The project follows [Semant
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-08-27
+
 ### Changed
 
 - Relicensed the project from MIT to GNU AGPL v3.0 only.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Context-efficient, correctness-first content search for the [Pi coding agent](https://pi.dev). Signal Grep keeps broad `ripgrep` output from flooding model context without pretending that truncated results are complete.
 
-> **Project status:** pre-release. The initial implementation is under review and has not been published to npm yet.
+> **Latest release:** `0.1.0`.
 
 ## Why Signal Grep?
 
@@ -118,7 +118,13 @@ This is a context-shape benchmark, not a search-speed or token-count benchmark. 
 
 ## Installation
 
-Install from GitHub after the initial pull request is merged:
+Install the latest release from npm:
+
+```bash
+pi install npm:pi-plugin-signal-grep
+```
+
+You can also install the current GitHub version:
 
 ```bash
 pi install git:github.com/xcjy8bao/pi-plugin-signal-grep
@@ -129,8 +135,6 @@ Then restart Pi. During local development:
 ```bash
 pi -e ./src/index.ts
 ```
-
-The planned npm package name is `pi-plugin-signal-grep`; no npm release exists yet.
 
 ## Tool
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 面向 [Pi 编码智能体](https://pi.dev) 的上下文高效、正确性优先的内容搜索插件。Signal Grep 避免宽泛的 `ripgrep` 结果淹没模型上下文，同时绝不会把被截断的结果伪装成完整结果。
 
-> **项目状态：** 预发布。首个实现正在通过 Pull Request 审查，尚未发布到 npm。
+> **最新版本：** `0.1.0`。
 
 ## 为什么需要 Signal Grep？
 
@@ -118,7 +118,13 @@ bun run benchmark
 
 ## 安装
 
-首个 Pull Request 合并后，可以从 GitHub 安装：
+从 npm 安装最新版本：
+
+```bash
+pi install npm:pi-plugin-signal-grep
+```
+
+也可以安装 GitHub 上的当前版本：
 
 ```bash
 pi install git:github.com/xcjy8bao/pi-plugin-signal-grep
@@ -129,8 +135,6 @@ pi install git:github.com/xcjy8bao/pi-plugin-signal-grep
 ```bash
 pi -e ./src/index.ts
 ```
-
-计划使用的 npm 包名是 `pi-plugin-signal-grep`，目前尚未发布 npm 版本。
 
 ## 工具接口
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "type": "module",
   "publishConfig": {
     "access": "public",
-    "provenance": true
+    "provenance": true,
+    "registry": "https://registry.npmjs.org"
   },
   "scripts": {
     "format": "oxfmt --write .",


### PR DESCRIPTION
## Summary

Prepares the repository and package metadata for the first public `0.1.0` release.

## Motivation

The implementation and quality gates are complete, and the maintainer authorized publishing the package to npm and the Pi package gallery.

## Public contract

No search tool schema, defaults, output, error, cursor, or compatibility behavior changes. Installation documentation now identifies npm as the primary release channel.

## Design and ownership

Release metadata remains in `package.json` and `CHANGELOG.md`; installation guidance remains in the English and Simplified Chinese READMEs. `publishConfig.registry` pins publication to the official npm registry so the developer's machine-level mirror setting cannot redirect a release.

## Validation

- [x] `bun install --frozen-lockfile`
- [x] `bun run check`
- [x] `bun run pack:check`
- [x] Real ripgrep integration behavior was tested when search semantics changed

```text
bun install --frozen-lockfile: no changes
bun run check: format, lint, typecheck, 18 tests, Node smoke test, and benchmark passed
bun run pack:check: 17 files, 98.73 KB unpacked
npm publish --dry-run --registry=https://registry.npmjs.org --provenance=false: passed
```

## Negative paths and invariants

- [ ] No retained match can be silently omitted or duplicated
- [ ] Partial, truncated, expired, cancelled, and failed states remain observable
- [ ] Process and snapshot lifecycle cleanup is covered
- [ ] `.git`, hidden-file, ignore, regex/literal, case, and glob behavior remains intentional
- [x] Not applicable; explain why below

Release-only documentation and package destination metadata changed. Runtime source and search semantics are untouched; the complete existing behavioral suite still passed.

## Risk and rollback

The material risk is publishing to the wrong registry; pinning `https://registry.npmjs.org` in `publishConfig` closes that path. Before publication, this PR can be reverted normally. npm versions are immutable after publication, so any post-publication correction requires a new patch version rather than overwriting `0.1.0`.

## Documentation

- [x] English README or docs updated
- [x] Simplified Chinese README updated when user-facing behavior changed
- [x] Changelog updated
- [ ] No documentation change required

## AI provenance

- **AI agent/model family:** OpenAI Codex / GPT-5.6
- **Human final-diff review:** No
- **Validation executed by AI:** `bun install --frozen-lockfile`, `bun run check`, `bun run pack:check`, `npm publish --dry-run --registry=https://registry.npmjs.org --provenance=false`, `git diff --check`
- **Unverified claims or remaining uncertainty:** npm account authentication is still required before the external publish action; Pi gallery indexing latency is outside this repository's control.

## Final review

- [x] The branch is focused and contains no unrelated changes
- [x] The final diff was reviewed
- [x] No generated artifacts, credentials, private source, or logs are committed
- [x] This PR does not publish, release, or merge itself
