### PR TITLE
feat: add cumulative token metrics status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes will be documented in this file. The project follows [Semant
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-27
+
+### Added
+
+- Opt-in, session-local Status Line metrics comparing cumulative Signal Grep result-text token estimates with Pi's normal grep baseline.
+- Honest cumulative accounting for cursor pages, negative savings, and searches that normal grep cannot represent equivalently.
+
 ## [0.1.1] - 2026-08-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Context-efficient, correctness-first content search for the [Pi coding agent](https://pi.dev). Signal Grep keeps broad `ripgrep` output from flooding model context without pretending that truncated results are complete.
 
-> **Latest release:** `0.1.1`.
+> **Latest release:** `0.2.0`.
 
 ## Why Signal Grep?
 
@@ -161,6 +161,32 @@ The extension registers one tool: `signal_grep`.
 - `matches`: return the first detail page immediately.
 - `cursor`: continue detail pages from the original snapshot; no search rerun.
 
+## Optional cumulative token comparison
+
+Token comparison is disabled by default and adds no baseline search while disabled. Start a fresh, session-local comparison window with:
+
+```text
+/signal-grep-metrics on
+```
+
+Pi adds a compact Extension Status below its built-in footer statistics and updates it after each comparable search:
+
+```text
+SG 3.2k / normal 11.8k · ↓8.6k (72.9%)
+```
+
+`SG` is the cumulative estimated token count of Signal Grep result text. `normal` is the cumulative estimate for Pi's normal grep result text on the same new searches. Cursor pages add to `SG` without rerunning or recounting the normal baseline. If exhaustive pagination costs more than normal grep, the indicator shows an honest increase such as `↑1.3k (11.0%)`.
+
+Counts use Pi's conservative characters-over-four heuristic and cover model-facing result text only—not tool schemas, provider serialization, or the extra model turn needed to request a cursor page. Exact UTF-8 byte totals are retained for the final report. Enabling metrics executes one additional normal grep process for each comparable new search. Searches using multiple include globs, exclude globs, or `hidden=false` are excluded with a visible warning because normal grep cannot represent those inputs equivalently.
+
+Stop the window, remove only Signal Grep's status, and show the final cumulative report with:
+
+```text
+/signal-grep-metrics off
+```
+
+Use `/signal-grep-metrics status` to inspect the active window without closing it. Metrics stay in memory, are reset on the next enable, and are never persisted or transmitted.
+
 ## Correctness contract
 
 Signal Grep treats search completeness as a public contract:
@@ -180,6 +206,7 @@ See [Architecture](docs/ARCHITECTURE.md) for the ownership and lifecycle model.
 
 - `/signal-grep-health` — show the detected ripgrep version and snapshot usage.
 - `/signal-grep-clear` — clear snapshots and invalidate existing cursors.
+- `/signal-grep-metrics on|off|status` — control or inspect cumulative Status Line token estimates.
 
 Snapshots are also cleared on Pi session shutdown.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 面向 [Pi 编码智能体](https://pi.dev) 的上下文高效、正确性优先的内容搜索插件。Signal Grep 避免宽泛的 `ripgrep` 结果淹没模型上下文，同时绝不会把被截断的结果伪装成完整结果。
 
-> **最新版本：** `0.1.1`。
+> **最新版本：** `0.2.0`。
 
 ## 为什么需要 Signal Grep？
 
@@ -161,6 +161,32 @@ pi -e ./src/index.ts
 - `matches`：立即返回第一页具体匹配。
 - `cursor`：从原始快照继续分页，不重新执行搜索。
 
+## 可选的累计 Token 对比
+
+Token 对比默认关闭；关闭时不会执行额外的基准搜索。使用以下命令开启一个全新、仅限当前会话的统计区间：
+
+```text
+/signal-grep-metrics on
+```
+
+Pi 会在内置 Footer 统计下方追加一条紧凑的扩展状态，并在每次可对比搜索后更新：
+
+```text
+SG 3.2k / normal 11.8k · ↓8.6k (72.9%)
+```
+
+`SG` 是 Signal Grep 结果文本的累计估算 Token，`normal` 是相同新搜索使用 Pi 普通 grep 时结果文本的累计估算 Token。cursor 页面只累加到 `SG`，不会重新执行或重复计算普通 grep 基准。如果完整分页比普通 grep 消耗更多，状态会如实显示 `↑1.3k (11.0%)` 之类的负收益。
+
+Token 使用 Pi 同样的保守“字符数除以四”启发式估算，只覆盖进入模型的结果文本，不包括工具 Schema、供应商序列化，或请求 cursor 页面所需的额外模型轮次。最终报告同时保留精确的 UTF-8 字节数。开启统计后，每个可对比的新搜索会额外执行一次普通 grep。多个包含 glob、排除 glob 或 `hidden=false` 无法由普通 grep 等价表达，因此会带有明确警告并排除在对比之外。
+
+使用以下命令结束统计区间、仅移除 Signal Grep 状态并显示最终累计报告：
+
+```text
+/signal-grep-metrics off
+```
+
+使用 `/signal-grep-metrics status` 可以查看当前区间而不关闭。指标只保存在内存中，下次开启时归零，不会持久化或传输。
+
 ## 正确性契约
 
 Signal Grep 将搜索完整性视为公开契约：
@@ -180,6 +206,7 @@ Signal Grep 将搜索完整性视为公开契约：
 
 - `/signal-grep-health`：查看 ripgrep 版本和快照使用情况。
 - `/signal-grep-clear`：清空快照并使现有 cursor 失效。
+- `/signal-grep-metrics on|off|status`：控制或查看 Status Line 累计 Token 估算。
 
 Pi 会话关闭时也会自动清理快照。
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,9 +21,11 @@ service.ts ── chooses auto/summary/matches behavior and composes results
     │
     ▼
 format.ts ─── owns model-facing summary, page, byte, and context formatting
+    │
+    └─► metrics.ts ── optionally compares cumulative result text with normal grep
 ```
 
-`index.ts` is the Pi adapter. It defines the schema, registers the tool and commands, and wires lifecycle cleanup. It contains no search algorithm.
+`index.ts` is the Pi adapter. It defines the schema, registers the tool and commands, and wires lifecycle cleanup. It contains no search algorithm. When the user explicitly enables metrics, the adapter executes Pi's normal grep after each comparable new search and passes both result texts to `metrics.ts`.
 
 ## Responsibilities
 
@@ -62,6 +64,10 @@ Snapshots are session-local and are cleared at shutdown. No state is persisted o
 
 `format.ts` owns only presentation boundaries. Detail pages stop before either the match count or byte budget is exceeded. Retained matching-line text always comes from the snapshot. Optional surrounding context is read lazily for files represented on the current page, may reflect edits made after the snapshot, and is omitted explicitly for files over 5 MiB or files that can no longer be read.
 
+### Opt-in comparison metrics
+
+`metrics.ts` owns one session-local comparison window, the characters-over-four token estimate, exact byte totals, and compact Status Line/report formatting. It is disabled by default. New comparable searches contribute one Signal Grep result and one Pi normal grep baseline; tracked cursor pages contribute only their Signal Grep result. Inputs normal grep cannot represent equivalently are visibly excluded instead of producing a misleading ratio. Metrics never alter model-facing search text, persist state, or transmit data.
+
 ## Core invariants
 
 - Completed retained snapshots paginate without omission or duplication.
@@ -70,6 +76,8 @@ Snapshots are session-local and are cleared at shutdown. No state is persisted o
 - Process errors never become an empty successful result.
 - Limits have one source of truth in `types.ts`.
 - Runtime source uses Node.js 22+ APIs and remains executable under Bun 1.4+.
+- Disabled metrics execute no normal grep baseline and add no status.
+- Metrics never recount a normal baseline for cursor continuation and never hide negative savings or unsupported comparisons.
 
 ## Deliberate non-goals
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-plugin-signal-grep",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Context-efficient, correctness-first ripgrep search for the Pi coding agent",
   "keywords": [
     "ai-agent",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { StringEnum } from "@earendil-works/pi-ai";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { createGrepTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
+import { createNormalGrepInput, METRICS_STATUS_KEY, SearchMetrics } from "./metrics.js";
 import { createRipgrepRunner } from "./rg.js";
 import { SignalGrepService } from "./service.js";
 
@@ -44,8 +45,20 @@ const searchSchema = Type.Object({
   ),
 });
 
+function resultText(content: Array<{ type: string; text?: string }>): string {
+  return content
+    .filter(
+      (item): item is { type: "text"; text: string } =>
+        item.type === "text" && typeof item.text === "string",
+    )
+    .map((item) => item.text)
+    .join("\n");
+}
+
 export default function signalGrepExtension(pi: ExtensionAPI) {
   const service = new SignalGrepService({ runRipgrep: createRipgrepRunner() });
+  const metrics = new SearchMetrics();
+  const trackedCursors = new Set<string>();
 
   pi.registerTool({
     name: "signal_grep",
@@ -61,7 +74,43 @@ export default function signalGrepExtension(pi: ExtensionAPI) {
     parameters: searchSchema,
 
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      const inputCursor = params.cursor;
+      const trackedCursor = inputCursor ? trackedCursors.has(inputCursor) : false;
       const result = await service.search(params, ctx.cwd, signal);
+
+      if (metrics.enabled) {
+        if (trackedCursor && inputCursor) {
+          trackedCursors.delete(inputCursor);
+          metrics.recordCursorPage(result.text);
+          if (result.details.cursor) trackedCursors.add(result.details.cursor);
+        } else if (!inputCursor) {
+          const normalInput = createNormalGrepInput(params);
+          if (!normalInput.supported) {
+            metrics.recordSkippedSearch();
+            ctx.ui.notify(
+              `Signal Grep metrics skipped this search: ${normalInput.reason}`,
+              "warning",
+            );
+          } else {
+            try {
+              const normalResult = await createGrepTool(ctx.cwd).execute(
+                "signal-grep-normal-baseline",
+                normalInput.input,
+                signal,
+              );
+              metrics.recordComparison(result.text, resultText(normalResult.content));
+              if (result.details.cursor) trackedCursors.add(result.details.cursor);
+            } catch (error) {
+              if (signal?.aborted) throw error;
+              metrics.recordSkippedSearch();
+              const message = error instanceof Error ? error.message : String(error);
+              ctx.ui.notify(`Signal Grep metrics baseline failed: ${message}`, "warning");
+            }
+          }
+        }
+        ctx.ui.setStatus(METRICS_STATUS_KEY, metrics.formatStatus());
+      }
+
       return {
         content: [{ type: "text", text: result.text }],
         details: result.details,
@@ -89,11 +138,61 @@ export default function signalGrepExtension(pi: ExtensionAPI) {
     description: "Clear all in-memory Signal Grep snapshots and invalidate their cursors",
     handler: async (_args, ctx) => {
       service.clear();
+      trackedCursors.clear();
       ctx.ui.notify("Signal Grep snapshots cleared", "info");
     },
   });
 
-  pi.on("session_shutdown", async () => {
+  pi.registerCommand("signal-grep-metrics", {
+    description: "Toggle or inspect cumulative Signal Grep versus normal grep token estimates",
+    handler: async (args, ctx) => {
+      const action = args.trim().toLowerCase();
+      if (action === "on") {
+        if (metrics.enabled) {
+          ctx.ui.notify("Signal Grep metrics are already enabled", "info");
+          return;
+        }
+        metrics.enable();
+        trackedCursors.clear();
+        ctx.ui.setStatus(METRICS_STATUS_KEY, metrics.formatStatus());
+        ctx.ui.notify(
+          "Signal Grep metrics enabled. Token counts are estimated from model-facing result text.",
+          "info",
+        );
+        return;
+      }
+
+      if (action === "off") {
+        if (!metrics.enabled) {
+          ctx.ui.notify("Signal Grep metrics are already disabled", "info");
+          return;
+        }
+        const report = metrics.formatReport();
+        metrics.disable();
+        trackedCursors.clear();
+        ctx.ui.setStatus(METRICS_STATUS_KEY, undefined);
+        ctx.ui.notify(report, "info");
+        return;
+      }
+
+      if (action === "status" || action.length === 0) {
+        ctx.ui.notify(
+          metrics.enabled
+            ? metrics.formatReport()
+            : "Signal Grep metrics are disabled. Use /signal-grep-metrics on to start a new comparison window.",
+          "info",
+        );
+        return;
+      }
+
+      ctx.ui.notify("Usage: /signal-grep-metrics on|off|status", "warning");
+    },
+  });
+
+  pi.on("session_shutdown", async (_event, ctx) => {
     service.clear();
+    trackedCursors.clear();
+    metrics.disable();
+    ctx.ui.setStatus(METRICS_STATUS_KEY, undefined);
   });
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,156 @@
+import type { GrepToolInput } from "@earendil-works/pi-coding-agent";
+import { normalizeRequest } from "./request.js";
+import type { SignalGrepInput } from "./service.js";
+
+export const METRICS_STATUS_KEY = "signal-grep-metrics";
+
+export interface MetricsSnapshot {
+  enabled: boolean;
+  signalTokens: number;
+  normalTokens: number;
+  signalBytes: number;
+  normalBytes: number;
+  searches: number;
+  cursorPages: number;
+  skippedSearches: number;
+}
+
+export type NormalGrepInputResult =
+  | { supported: true; input: GrepToolInput }
+  | { supported: false; reason: string };
+
+function smartCaseIsInsensitive(pattern: string): boolean {
+  return pattern === pattern.toLocaleLowerCase();
+}
+
+export function createNormalGrepInput(input: SignalGrepInput): NormalGrepInputResult {
+  if (!input.pattern?.trim()) return { supported: false, reason: "pattern is unavailable" };
+  const request = normalizeRequest(input);
+  if (!request.hidden) {
+    return { supported: false, reason: "normal grep always includes hidden files" };
+  }
+  if (request.exclude.length > 0) {
+    return { supported: false, reason: "normal grep does not support exclude globs" };
+  }
+  if (request.glob.length > 1) {
+    return { supported: false, reason: "normal grep accepts only one include glob" };
+  }
+
+  return {
+    supported: true,
+    input: {
+      pattern: request.pattern,
+      ...(request.path ? { path: request.path } : {}),
+      ...(request.glob[0] ? { glob: request.glob[0] } : {}),
+      literal: request.literal,
+      ignoreCase: request.ignoreCase ?? smartCaseIsInsensitive(request.pattern),
+      context: request.context,
+    },
+  };
+}
+
+export function estimateTextTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function formatTokens(count: number): string {
+  if (count < 1_000) return String(count);
+  if (count < 10_000) return `${(count / 1_000).toFixed(1)}k`;
+  if (count < 1_000_000) return `${Math.round(count / 1_000)}k`;
+  if (count < 10_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  return `${Math.round(count / 1_000_000)}M`;
+}
+
+function formatBytes(count: number): string {
+  if (count < 1_024) return `${count} B`;
+  if (count < 1_024 * 1_024) return `${(count / 1_024).toFixed(1)} KiB`;
+  return `${(count / (1_024 * 1_024)).toFixed(1)} MiB`;
+}
+
+function comparison(snapshot: MetricsSnapshot): {
+  difference: number;
+  percentage: number;
+  improved: boolean;
+} {
+  const difference = snapshot.normalTokens - snapshot.signalTokens;
+  return {
+    difference,
+    percentage:
+      snapshot.normalTokens === 0 ? 0 : (Math.abs(difference) / snapshot.normalTokens) * 100,
+    improved: difference >= 0,
+  };
+}
+
+export class SearchMetrics {
+  #snapshot: MetricsSnapshot = this.#empty(false);
+
+  enable(): MetricsSnapshot {
+    this.#snapshot = this.#empty(true);
+    return this.snapshot;
+  }
+
+  disable(): MetricsSnapshot {
+    this.#snapshot.enabled = false;
+    return this.snapshot;
+  }
+
+  recordComparison(signalText: string, normalText: string): void {
+    if (!this.#snapshot.enabled) return;
+    this.#snapshot.signalTokens += estimateTextTokens(signalText);
+    this.#snapshot.normalTokens += estimateTextTokens(normalText);
+    this.#snapshot.signalBytes += Buffer.byteLength(signalText);
+    this.#snapshot.normalBytes += Buffer.byteLength(normalText);
+    this.#snapshot.searches += 1;
+  }
+
+  recordCursorPage(signalText: string): void {
+    if (!this.#snapshot.enabled) return;
+    this.#snapshot.signalTokens += estimateTextTokens(signalText);
+    this.#snapshot.signalBytes += Buffer.byteLength(signalText);
+    this.#snapshot.cursorPages += 1;
+  }
+
+  recordSkippedSearch(): void {
+    if (!this.#snapshot.enabled) return;
+    this.#snapshot.skippedSearches += 1;
+  }
+
+  get enabled(): boolean {
+    return this.#snapshot.enabled;
+  }
+
+  get snapshot(): MetricsSnapshot {
+    return { ...this.#snapshot };
+  }
+
+  formatStatus(): string {
+    const snapshot = this.snapshot;
+    const result = comparison(snapshot);
+    const warning = snapshot.skippedSearches > 0 ? ` · ⚠${snapshot.skippedSearches}` : "";
+    return `SG ${formatTokens(snapshot.signalTokens)} / normal ${formatTokens(snapshot.normalTokens)} · ${result.improved ? "↓" : "↑"}${formatTokens(Math.abs(result.difference))} (${result.percentage.toFixed(1)}%)${warning}`;
+  }
+
+  formatReport(): string {
+    const snapshot = this.snapshot;
+    const result = comparison(snapshot);
+    const outcome = result.improved ? "saved" : "used an additional";
+    const skipped =
+      snapshot.skippedSearches > 0
+        ? ` ${snapshot.skippedSearches} unsupported search${snapshot.skippedSearches === 1 ? " was" : "es were"} excluded from the comparison.`
+        : "";
+    return `Signal Grep metrics: SG ${formatTokens(snapshot.signalTokens)} estimated tokens (${formatBytes(snapshot.signalBytes)}) / normal ${formatTokens(snapshot.normalTokens)} (${formatBytes(snapshot.normalBytes)}) · ${outcome} ${formatTokens(Math.abs(result.difference))} (${result.percentage.toFixed(1)}%) across ${snapshot.searches} searches and ${snapshot.cursorPages} cursor pages.${skipped}`;
+  }
+
+  #empty(enabled: boolean): MetricsSnapshot {
+    return {
+      enabled,
+      signalTokens: 0,
+      normalTokens: 0,
+      signalBytes: 0,
+      normalBytes: 0,
+      searches: 0,
+      cursorPages: 0,
+      skippedSearches: 0,
+    };
+  }
+}

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import { createGrepTool } from "@earendil-works/pi-coding-agent";
+import { createNormalGrepInput, estimateTextTokens, SearchMetrics } from "../src/metrics.js";
+import { createRipgrepRunner } from "../src/rg.js";
+import { SignalGrepService } from "../src/service.js";
+import { createTodoFixture, removeFixture } from "./helpers.js";
+
+function textContent(content: Array<{ type: string; text?: string }>): string {
+  return content.find((item) => item.type === "text")?.text ?? "";
+}
+
+describe("normal grep comparison input", () => {
+  test("maps the common Signal Grep request to normal grep semantics", () => {
+    expect(
+      createNormalGrepInput({
+        pattern: "todo",
+        path: "@src",
+        glob: "*.ts",
+        literal: true,
+        context: 2,
+      }),
+    ).toEqual({
+      supported: true,
+      input: {
+        pattern: "todo",
+        path: "src",
+        glob: "*.ts",
+        literal: true,
+        ignoreCase: true,
+        context: 2,
+      },
+    });
+  });
+
+  test("preserves smart-case behavior in the normal grep baseline", () => {
+    const result = createNormalGrepInput({ pattern: "TODO" });
+    expect(result).toMatchObject({ supported: true, input: { ignoreCase: false } });
+  });
+
+  test("rejects filters normal grep cannot represent instead of comparing different searches", () => {
+    expect(createNormalGrepInput({ pattern: "x", exclude: "generated/**" })).toEqual({
+      supported: false,
+      reason: "normal grep does not support exclude globs",
+    });
+    expect(createNormalGrepInput({ pattern: "x", glob: ["*.ts", "*.tsx"] })).toEqual({
+      supported: false,
+      reason: "normal grep accepts only one include glob",
+    });
+    expect(createNormalGrepInput({ pattern: "x", hidden: false })).toEqual({
+      supported: false,
+      reason: "normal grep always includes hidden files",
+    });
+  });
+});
+
+describe("SearchMetrics", () => {
+  test("is disabled by default and starts a fresh cumulative window when enabled", () => {
+    const metrics = new SearchMetrics();
+    metrics.recordComparison("signal", "normal output");
+    expect(metrics.snapshot).toMatchObject({ enabled: false, searches: 0 });
+
+    metrics.enable();
+    expect(metrics.formatStatus()).toBe("SG 0 / normal 0 · ↓0 (0.0%)");
+    metrics.recordComparison("x".repeat(400), "x".repeat(1_200));
+    metrics.recordCursorPage("x".repeat(200));
+
+    expect(metrics.snapshot).toMatchObject({
+      enabled: true,
+      signalTokens: 150,
+      normalTokens: 300,
+      searches: 1,
+      cursorPages: 1,
+    });
+    expect(metrics.formatStatus()).toBe("SG 150 / normal 300 · ↓150 (50.0%)");
+  });
+
+  test("shows negative savings and excluded comparisons without hiding them", () => {
+    const metrics = new SearchMetrics();
+    metrics.enable();
+    metrics.recordComparison("x".repeat(800), "x".repeat(400));
+    metrics.recordSkippedSearch();
+
+    expect(metrics.formatStatus()).toBe("SG 200 / normal 100 · ↑100 (100.0%) · ⚠1");
+    expect(metrics.formatReport()).toContain("used an additional 100 (100.0%)");
+    expect(metrics.formatReport()).toContain("1 unsupported search was excluded");
+  });
+
+  test("uses the same conservative characters-over-four estimate as Pi", () => {
+    expect(estimateTextTokens("")).toBe(0);
+    expect(estimateTextTokens("12345")).toBe(2);
+  });
+
+  test("stops accumulating after the comparison window closes", () => {
+    const metrics = new SearchMetrics();
+    metrics.enable();
+    metrics.recordComparison("1234", "12345678");
+    const final = metrics.disable();
+    metrics.recordCursorPage("1234");
+
+    expect(final).toMatchObject({ enabled: false, signalTokens: 1, normalTokens: 2 });
+    expect(metrics.snapshot).toEqual(final);
+  });
+
+  test("compares real Signal Grep and normal grep model-facing result text", async () => {
+    const root = await createTodoFixture();
+    try {
+      const signalResult = await new SignalGrepService({
+        runRipgrep: createRipgrepRunner(),
+      }).search({ pattern: "TODO" }, root);
+      const normalResult = await createGrepTool(root).execute("metrics-test", {
+        pattern: "TODO",
+      });
+      const metrics = new SearchMetrics();
+      metrics.enable();
+      metrics.recordComparison(signalResult.text, textContent(normalResult.content));
+
+      expect(metrics.snapshot.searches).toBe(1);
+      expect(metrics.snapshot.signalTokens).toBeLessThan(metrics.snapshot.normalTokens);
+      expect(metrics.formatStatus()).toMatch(/^SG \d+ \/ normal \d+ · ↓\d+ \(\d+\.\d%\)$/);
+    } finally {
+      await removeFixture(root);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds an opt-in, session-local cumulative token comparison window rendered through Pi's Extension Status Line.

Users can run `/signal-grep-metrics on` to start at zero, use Signal Grep normally, inspect with `/signal-grep-metrics status`, and run `/signal-grep-metrics off` to clear only this extension's status and receive a final report.

## Motivation

Signal Grep already has a reproducible fixture benchmark, but users could not observe its effect across their own real searches and cursor usage. This adds honest cumulative result-text accounting without changing default behavior.

## Public contract

- New command: `/signal-grep-metrics on|off|status`.
- Default remains off; disabled mode runs no normal grep baseline and adds no status.
- Status format: `SG 3.2k / normal 11.8k · ↓8.6k (72.9%)`.
- Cursor pages add only to the Signal Grep total; the normal baseline is counted once per comparable new search.
- Negative savings and unsupported comparisons remain visible.
- Estimates use Pi's conservative characters-over-four heuristic and exact UTF-8 bytes are retained for reports.

No `signal_grep` input schema, search output text, cursor, completeness, or failure contract changes.

## Design and ownership

`src/metrics.ts` owns comparison-window state, normalized normal-grep input mapping, estimates, byte totals, and formatting. `src/index.ts` owns Pi integration: command lifecycle, the unique `signal-grep-metrics` status key, baseline execution, cursor association, and shutdown cleanup.

The built-in footer is not replaced. `ctx.ui.setStatus()` appends an extension status line and `setStatus(key, undefined)` removes only this extension's entry.

## Validation

- [x] `bun install --frozen-lockfile`
- [x] `bun run check`
- [x] `bun run pack:check`
- [x] Real ripgrep integration behavior was tested when search semantics changed

```text
bun run check: format, type-aware lint, TypeScript, 26 tests, Node smoke, and benchmark passed
bun run pack:check: 20 files, 116.38 KB unpacked
npm publish --dry-run: pi-plugin-signal-grep@0.2.0, src/metrics.ts included
TUI smoke in isolated PI_CODING_AGENT_DIR:
  on  -> SG 0 / normal 0 · ↓0 (0.0%) appended below built-in footer
  off -> final report displayed and extension status cleared
Real comparison integration fixture: Signal Grep estimated result tokens < normal grep estimate
```

## Negative paths and invariants

- [x] No retained match can be silently omitted or duplicated
- [x] Partial, truncated, expired, cancelled, and failed states remain observable
- [x] Process and snapshot lifecycle cleanup is covered
- [x] `.git`, hidden-file, ignore, regex/literal, case, and glob behavior remains intentional
- [ ] Not applicable; explain why below

Metrics do not modify search text or snapshots. A cancelled normal baseline preserves cancellation. Baseline failures and inputs normal grep cannot represent equivalently are visibly excluded instead of changing search success or reporting a misleading ratio. Invalid cursor attempts do not consume tracked cursor accounting.

## Risk and rollback

When explicitly enabled, one extra normal grep process runs per comparable new search, increasing latency and local CPU/I/O. This is documented and absent while disabled. Revert this PR to remove the command and metrics module; search behavior is otherwise unchanged.

## Documentation

- [x] English README or docs updated
- [x] Simplified Chinese README updated when user-facing behavior changed
- [x] Changelog updated
- [ ] No documentation change required

## AI provenance

- **AI agent/model family:** OpenAI Codex / GPT-5.6
- **Human final-diff review:** No
- **Validation executed by AI:** full project gates, package dry run with required-file assertions, pure unit tests, real normal-grep comparison integration test, isolated tmux Pi TUI lifecycle smoke, final staged diff review
- **Unverified claims or remaining uncertainty:** exact provider tokenization varies by model, so the UI intentionally labels reports as estimates; Pi Gallery cache refresh timing is externally controlled.

## Final review

- [x] The branch is focused and contains no unrelated changes
- [x] The final diff was reviewed
- [x] No generated artifacts, credentials, private source, or logs are committed
- [x] This PR does not publish, release, or merge itself
