### PR TITLE
fix: degrade grep override safely when another package owns grep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes will be documented in this file. The project follows [Semant
 
 ## [Unreleased]
 
+### Fixed
+
+- Load-time conflict detection: when the built-in `grep` override is configured but a package that owns the public `grep` tool name is installed (for example `pi-hashline-edit-pro`), Signal Grep now degrades to additive `signal_grep` for that session with a visible notice instead of failing the whole extension set at startup. The config value is never rewritten, and removing the conflicting package restores the override on the next load.
+- `/signal-grep-metrics on` and the `startMetricsOnNextLoad` handoff no longer persist an override that cannot take effect: they refuse with a clear notice while a conflicting package is installed.
+
 ## [0.4.0] - 2026-08-28
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,6 +8,9 @@ Signal Grep is intentionally a composition of single-purpose components. It opti
 config.ts ─── selects additive `signal_grep` or opt-in built-in `grep` override
     │
     ▼
+conflicts.ts ─ detects installed packages that own the public "grep" tool name
+    │
+    ▼
 Pi tool input
     │
     ▼
@@ -32,13 +35,15 @@ format.ts ─── owns model-facing summary, page, byte, and deduplicated cont
     └─► metrics.ts ── optionally compares cumulative result text with normal grep
 ```
 
-`index.ts` is the Pi adapter. It defines the schema, registers exactly one Signal Grep tool, registers commands, and wires lifecycle cleanup. `runtime.ts` owns the service/metrics/cursor coordination used by the tool. It contains no search algorithm. Additive mode uses `signal_grep`; explicit override mode uses `grep` and replaces Pi's built-in implementation. When metrics are enabled, `service.ts` derives both Signal Grep and normal-format text from the same snapshot and passes them to `metrics.ts`. Pi and OMP use the same adapter contract; structure providers remain host-independent.
+`index.ts` is the Pi adapter. It defines the schema, registers exactly one Signal Grep tool, registers commands, and wires lifecycle cleanup. `runtime.ts` owns the service/metrics/cursor coordination used by the tool. It contains no search algorithm. Additive mode uses `signal_grep`; explicit override mode uses `grep` and replaces Pi's built-in implementation. When metrics are enabled, `service.ts` derives both Signal Grep and normal-format text from the same snapshot and passes them to `metrics.ts`. `messages.ts` owns the templates for human-facing command and notification text; model-facing tool response text is intentionally not routed through it.
 
 ## Responsibilities
 
 ### Persistent tool mode
 
-`config.ts` owns the user-global `signal-grep.json` contract and staged writes. Missing config means additive mode. A one-shot `startMetricsOnNextLoad` handoff lets `/signal-grep-metrics on` persist the override, reload, clear the handoff, and start session-local Metrics without requiring a second command. Invalid JSON or a mistyped value fails clearly instead of silently changing which public tool owns `grep`. Override commands inspect the active grep source and refuse to persist when another extension already owns it. Pi's extension loader also rejects duplicate `grep` registrations, so conflicts fail closed rather than creating ambiguous ownership.
+`config.ts` owns the user-global `signal-grep.json` contract and staged writes. Missing config means additive mode. A one-shot `startMetricsOnNextLoad` handoff lets `/signal-grep-metrics on` persist the override, reload, clear the handoff, and start session-local Metrics without requiring a second command. Invalid JSON or a mistyped value fails clearly instead of silently changing which public tool owns `grep`. Override commands inspect the active grep source and refuse to persist when another extension already owns it.
+
+Because Pi's extension loader rejects duplicate `grep` registrations at load time and fails the whole extension set, config intent alone cannot decide the effective tool name. `conflicts.ts` keeps the data table of packages known to register their own public `grep` tool and detects them in the agent package directory on every load. When the override is configured but such a package is installed, the override degrades to additive `signal_grep` for that session with a visible notice, the config value is never rewritten, and removing the conflicting package restores the override on the next load. Metrics enablement requires an actually active override and is refused while degraded. If conflict detection itself fails, the extension degrades to additive mode and names the detection failure instead of treating it as "no conflict".
 
 ### Request normalization
 

--- a/src/conflicts.ts
+++ b/src/conflicts.ts
@@ -39,8 +39,13 @@ export async function detectGrepOwnerConflict(
   for (const entry of topLevelEntries) installed.add(entry);
   const scopedGroups = await Promise.all(
     scopedEntries.map(async (scope) => {
-      const names = await readdir(join(nodeModules, scope)).catch(() => []);
-      return names.map((name) => `${scope}/${name}`);
+      try {
+        const names = await readdir(join(nodeModules, scope));
+        return names.map((name) => `${scope}/${name}`);
+      } catch (error) {
+        if (hasErrorCode(error, ["ENOENT"])) return [];
+        throw error;
+      }
     }),
   );
   for (const group of scopedGroups) {

--- a/src/conflicts.ts
+++ b/src/conflicts.ts
@@ -1,0 +1,50 @@
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * Packages known to register their own public "grep" tool. Signal Grep override
+ * mode cannot own "grep" while any of these is installed, because Pi's extension
+ * loader rejects duplicate tool registrations and the whole extension set fails
+ * to load. Extend this table as the ecosystem grows; do not add ad hoc checks.
+ */
+export const GREP_OWNER_PACKAGES: readonly string[] = ["pi-hashline-edit-pro"];
+
+function hasErrorCode(error: unknown, codes: string[]): boolean {
+  return error instanceof Error && "code" in error && codes.includes(String(error.code));
+}
+
+/**
+ * Detect an installed package that owns the public "grep" tool name by scanning
+ * the Pi agent package directory (top-level and @scope entries). Returns the
+ * conflicting package name, or undefined when none is installed. A missing
+ * package directory means no conflict; any other read failure propagates to the
+ * caller so it is never silently treated as "no conflict".
+ */
+export async function detectGrepOwnerConflict(
+  agentDir: string,
+  packages: readonly string[] = GREP_OWNER_PACKAGES,
+): Promise<string | undefined> {
+  const nodeModules = join(agentDir, "npm", "node_modules");
+  let entries: string[];
+  try {
+    entries = await readdir(nodeModules);
+  } catch (error) {
+    if (hasErrorCode(error, ["ENOENT"])) return undefined;
+    throw error;
+  }
+
+  const installed = new Set<string>();
+  const scopedEntries = entries.filter((entry) => entry.startsWith("@"));
+  const topLevelEntries = entries.filter((entry) => !entry.startsWith("@"));
+  for (const entry of topLevelEntries) installed.add(entry);
+  const scopedGroups = await Promise.all(
+    scopedEntries.map(async (scope) => {
+      const names = await readdir(join(nodeModules, scope)).catch(() => []);
+      return names.map((name) => `${scope}/${name}`);
+    }),
+  );
+  for (const group of scopedGroups) {
+    for (const name of group) installed.add(name);
+  }
+  return packages.find((candidate) => installed.has(candidate));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,10 @@
 import { StringEnum } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
+import { detectGrepOwnerConflict } from "./conflicts.js";
 import { readSignalGrepConfig, type SignalGrepConfig, writeSignalGrepConfig } from "./config.js";
+import { message } from "./messages.js";
 import { createRipgrepRunner } from "./rg.js";
 import { createCtagsStructureProvider } from "./structure.js";
 import { METRICS_STATUS_KEY, SignalGrepRuntime } from "./runtime.js";
@@ -10,6 +13,13 @@ import { type SignalGrepInput, SignalGrepService } from "./service.js";
 const SIGNAL_GREP_LABEL = "Signal Grep";
 const SIGNAL_GREP_DESCRIPTION =
   "Context-efficient ripgrep search with exact match ranges and bounded code inspection. Small searches return grouped matches; broad searches return a per-file summary first. Use mode=inspect with path and line to inspect a source block. Cursor pages come from a stable snapshot and explicitly report partial retention.";
+
+export interface SignalGrepExtensionOptions {
+  /** Overrides the Pi agent directory used for package conflict detection and config writes (test seam). */
+  agentDir?: string;
+  /** Overrides conflict detection entirely (test seam). */
+  detectConflict?: () => Promise<string | undefined>;
+}
 
 function formatMetricsStatus(runtime: SignalGrepRuntime, ctx: ExtensionContext): string {
   const theme = ctx.ui.theme;
@@ -82,19 +92,54 @@ export function grepOverrideConflictSource(
 export function effectiveSignalGrepInput(
   input: SignalGrepInput,
   config: SignalGrepConfig,
+  overrideActive: boolean = config.overrideBuiltinGrep,
 ): SignalGrepInput {
-  if (!config.overrideBuiltinGrep || input.cursor || input.ignoreCase !== undefined) return input;
+  if (!overrideActive || input.cursor || input.ignoreCase !== undefined) return input;
   return { ...input, ignoreCase: false };
 }
 
-export function registerSignalGrepExtension(pi: ExtensionAPI, config: SignalGrepConfig) {
+/**
+ * Resolve whether Signal Grep override mode can actually own "grep" in this
+ * session. Config intent alone is not enough: when a package from the known
+ * conflict table is installed, Pi's loader would reject the duplicate "grep"
+ * registration and refuse to start the whole extension set, so the override
+ * degrades to additive "signal_grep" with a visible notice instead. The config
+ * value is never rewritten: removing the conflicting package restores the
+ * override on the next load.
+ */
+export async function resolveOverrideActive(
+  config: SignalGrepConfig,
+  options: SignalGrepExtensionOptions = {},
+): Promise<{ overrideActive: boolean; conflict: string | undefined }> {
+  if (!config.overrideBuiltinGrep) return { overrideActive: false, conflict: undefined };
+  const fallbackDetect = (): Promise<string | undefined> =>
+    detectGrepOwnerConflict(options.agentDir ?? getAgentDir());
+  const detect = options.detectConflict ?? fallbackDetect;
+  try {
+    const conflict = await detect();
+    return { overrideActive: conflict === undefined, conflict };
+  } catch {
+    // Fail safe: additive mode always loads cleanly, and the notice names the
+    // detection failure instead of pretending no conflict exists.
+    return { overrideActive: false, conflict: "unknown (conflict detection failed)" };
+  }
+}
+
+export async function registerSignalGrepExtension(
+  pi: ExtensionAPI,
+  config: SignalGrepConfig,
+  options: SignalGrepExtensionOptions = {},
+): Promise<void> {
   const runtime = new SignalGrepRuntime(
     new SignalGrepService({
       runRipgrep: createRipgrepRunner(),
       structure: createCtagsStructureProvider(),
     }),
   );
-  const toolName = signalGrepToolName(config);
+  const agentDir = options.agentDir ?? getAgentDir();
+  const { overrideActive, conflict } = await resolveOverrideActive(config, options);
+  const degradedOverride = config.overrideBuiltinGrep && !overrideActive;
+  const toolName = overrideActive ? "grep" : "signal_grep";
 
   pi.registerTool({
     name: toolName,
@@ -111,7 +156,7 @@ export function registerSignalGrepExtension(pi: ExtensionAPI, config: SignalGrep
 
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       const result = await runtime.search(
-        effectiveSignalGrepInput(params, config),
+        effectiveSignalGrepInput(params, config, overrideActive),
         ctx.cwd,
         signal,
       );
@@ -147,8 +192,13 @@ export function registerSignalGrepExtension(pi: ExtensionAPI, config: SignalGrep
         .toSorted();
       const activeGrepOwner =
         tools.find((tool) => tool.name === "grep")?.sourceInfo.source ?? "missing";
+      const effectiveMode = overrideActive
+        ? "override built-in grep"
+        : degradedOverride
+          ? message("healthDegradedMode", { source: conflict ?? "unknown" })
+          : "additive signal_grep";
       ctx.ui.notify(
-        `${version}\nStructure provider: ${ctagsVersion}\nTool mode: ${config.overrideBuiltinGrep ? "override built-in grep" : "additive signal_grep"}\nSearch tools: ${searchTools.join(", ")}\nActive grep owner: ${activeGrepOwner}\nSnapshots: ${runtime.snapshotCount}\nRetained matches: ${runtime.storedMatches}`,
+        `${version}\nStructure provider: ${ctagsVersion}\nTool mode (effective): ${effectiveMode}\nSearch tools: ${searchTools.join(", ")}\nActive grep owner: ${activeGrepOwner}\nSnapshots: ${runtime.snapshotCount}\nRetained matches: ${runtime.storedMatches}`,
         "info",
       );
     },
@@ -188,6 +238,11 @@ export function registerSignalGrepExtension(pi: ExtensionAPI, config: SignalGrep
       }
 
       if (overrideBuiltinGrep) {
+        const packageConflict = await detectGrepOwnerConflict(agentDir);
+        if (packageConflict) {
+          ctx.ui.notify(message("overrideEnableRefused", { source: packageConflict }), "error");
+          return;
+        }
         const conflictSource = grepOverrideConflictSource(pi.getAllTools());
         if (conflictSource) {
           ctx.ui.notify(
@@ -198,10 +253,13 @@ export function registerSignalGrepExtension(pi: ExtensionAPI, config: SignalGrep
         }
       }
 
-      await writeSignalGrepConfig({
-        overrideBuiltinGrep,
-        startMetricsOnNextLoad: false,
-      });
+      await writeSignalGrepConfig(
+        {
+          overrideBuiltinGrep,
+          startMetricsOnNextLoad: false,
+        },
+        agentDir,
+      );
       ctx.ui.notify(
         `Signal Grep override ${overrideBuiltinGrep ? "enabled" : "disabled"}; reloading tools.`,
         "info",
@@ -219,7 +277,22 @@ export function registerSignalGrepExtension(pi: ExtensionAPI, config: SignalGrep
           ctx.ui.notify("Signal Grep metrics are already enabled", "info");
           return;
         }
+        if (degradedOverride) {
+          ctx.ui.notify(
+            message("metricsRequiresOverride", { source: conflict ?? "unknown" }),
+            "warning",
+          );
+          return;
+        }
         if (!config.overrideBuiltinGrep) {
+          const packageConflict = await detectGrepOwnerConflict(agentDir);
+          if (packageConflict) {
+            ctx.ui.notify(
+              message("metricsRequiresOverride", { source: packageConflict }),
+              "warning",
+            );
+            return;
+          }
           const conflictSource = grepOverrideConflictSource(pi.getAllTools());
           if (conflictSource) {
             ctx.ui.notify(
@@ -228,10 +301,13 @@ export function registerSignalGrepExtension(pi: ExtensionAPI, config: SignalGrep
             );
             return;
           }
-          await writeSignalGrepConfig({
-            overrideBuiltinGrep: true,
-            startMetricsOnNextLoad: true,
-          });
+          await writeSignalGrepConfig(
+            {
+              overrideBuiltinGrep: true,
+              startMetricsOnNextLoad: true,
+            },
+            agentDir,
+          );
           ctx.ui.notify(
             "Enabling the grep override and reloading before Signal Grep metrics start.",
             "info",
@@ -275,11 +351,24 @@ export function registerSignalGrepExtension(pi: ExtensionAPI, config: SignalGrep
   });
 
   pi.on("session_start", async (_event, ctx) => {
+    if (degradedOverride) {
+      ctx.ui.notify(message("overrideDegraded", { source: conflict ?? "unknown" }), "warning");
+    }
     if (!config.startMetricsOnNextLoad) return;
-    await writeSignalGrepConfig({
-      overrideBuiltinGrep: true,
-      startMetricsOnNextLoad: false,
-    });
+    await writeSignalGrepConfig(
+      {
+        overrideBuiltinGrep: true,
+        startMetricsOnNextLoad: false,
+      },
+      agentDir,
+    );
+    if (degradedOverride) {
+      ctx.ui.notify(
+        message("metricsRequiresOverride", { source: conflict ?? "unknown" }),
+        "warning",
+      );
+      return;
+    }
     runtime.enableMetrics();
     ctx.ui.setStatus(METRICS_STATUS_KEY, formatMetricsStatus(runtime, ctx));
     ctx.ui.notify(
@@ -296,5 +385,5 @@ export function registerSignalGrepExtension(pi: ExtensionAPI, config: SignalGrep
 }
 
 export default async function signalGrepExtension(pi: ExtensionAPI) {
-  registerSignalGrepExtension(pi, await readSignalGrepConfig());
+  await registerSignalGrepExtension(pi, await readSignalGrepConfig());
 }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,33 @@
+/**
+ * Templates for human-facing Signal Grep messages: command output, status line,
+ * and notifications. Tool response text is intentionally NOT routed through
+ * this module — it is read by the model and stays in English regardless of any
+ * future locale setting. Structured `details` fields are protocol constants and
+ * are never localized.
+ */
+const EN = {
+  overrideDegraded:
+    'Signal Grep override is enabled in config, but "grep" is owned by {source}. ' +
+    'Loading additively as "signal_grep" for this session. ' +
+    'Remove {source} to restore the override, or set "overrideBuiltinGrep": false to keep additive mode.',
+  metricsRequiresOverride:
+    'Signal Grep metrics require the built-in grep override, but "grep" is owned by {source}. ' +
+    "Metrics were not enabled.",
+  overrideEnableRefused:
+    'Cannot enable Signal Grep override: "{source}" is installed and owns the public "grep" tool name. ' +
+    'Remove it first, or keep using additive "signal_grep".',
+  healthDegradedMode: 'degraded to additive "signal_grep" (conflict: {source})',
+} as const;
+
+export type MessageKey = keyof typeof EN;
+export type MessageParams = Readonly<Record<string, string>>;
+
+export function message(key: MessageKey, params?: MessageParams): string {
+  let text: string = EN[key];
+  if (params) {
+    for (const [name, value] of Object.entries(params)) {
+      text = text.replaceAll(`{${name}}`, value);
+    }
+  }
+  return text;
+}

--- a/test/conflicts.test.ts
+++ b/test/conflicts.test.ts
@@ -1,0 +1,51 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { detectGrepOwnerConflict } from "../src/conflicts.js";
+
+const tempDirs: string[] = [];
+
+async function createAgentDir(structure: string[] = []): Promise<string> {
+  const agentDir = await mkdtemp(join(tmpdir(), "signal-grep-conflicts-"));
+  tempDirs.push(agentDir);
+  const nodeModules = join(agentDir, "npm", "node_modules");
+  await mkdir(nodeModules, { recursive: true });
+  await Promise.all(structure.map((entry) => mkdir(join(nodeModules, entry), { recursive: true })));
+  return agentDir;
+}
+
+afterEach(async () => {
+  const dirs = tempDirs.splice(0, tempDirs.length);
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("detectGrepOwnerConflict", () => {
+  test("returns undefined when the npm package directory is missing", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "signal-grep-conflicts-"));
+    tempDirs.push(agentDir);
+    expect(await detectGrepOwnerConflict(agentDir)).toBeUndefined();
+  }, 5_000);
+
+  test("returns undefined when no known grep owner is installed", async () => {
+    const agentDir = await createAgentDir(["pi-lens", "@juicesharp/rpiv-todo"]);
+    expect(await detectGrepOwnerConflict(agentDir)).toBeUndefined();
+  }, 5_000);
+
+  test("detects an installed top-level grep owner package", async () => {
+    const agentDir = await createAgentDir(["pi-lens", "pi-hashline-edit-pro"]);
+    expect(await detectGrepOwnerConflict(agentDir)).toBe("pi-hashline-edit-pro");
+  }, 5_000);
+
+  test("detects an installed scoped grep owner package", async () => {
+    const agentDir = await createAgentDir(["@example/grep-owner"]);
+    const packages = ["@example/grep-owner"];
+    expect(await detectGrepOwnerConflict(agentDir, packages)).toBe("@example/grep-owner");
+  }, 5_000);
+
+  test("does not match packages outside the owner table", async () => {
+    const agentDir = await createAgentDir(["pi-hashline-edit-pro-extras", "@example/other"]);
+    expect(await detectGrepOwnerConflict(agentDir)).toBeUndefined();
+    expect(await detectGrepOwnerConflict(agentDir, ["@example/grep-owner"])).toBeUndefined();
+  }, 5_000);
+});

--- a/test/conflicts.test.ts
+++ b/test/conflicts.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
@@ -41,6 +41,13 @@ describe("detectGrepOwnerConflict", () => {
     const agentDir = await createAgentDir(["@example/grep-owner"]);
     const packages = ["@example/grep-owner"];
     expect(await detectGrepOwnerConflict(agentDir, packages)).toBe("@example/grep-owner");
+  }, 5_000);
+
+  test("propagates scoped package directory read failures", async () => {
+    const agentDir = await createAgentDir();
+    await writeFile(join(agentDir, "npm", "node_modules", "@broken"), "not a directory");
+
+    expect(detectGrepOwnerConflict(agentDir, ["@broken/grep-owner"])).rejects.toThrow();
   }, 5_000);
 
   test("does not match packages outside the owner table", async () => {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,9 +1,19 @@
-import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
 import {
   effectiveSignalGrepInput,
   grepOverrideConflictSource,
+  registerSignalGrepExtension,
   signalGrepToolName,
 } from "../src/index.js";
+import { readSignalGrepConfig, writeSignalGrepConfig } from "../src/config.js";
 
 describe("Signal Grep tool mode", () => {
   test("keeps additive signal_grep as the safe default", () => {
@@ -40,4 +50,240 @@ describe("Signal Grep tool mode", () => {
       cursor: "cursor",
     });
   });
+
+  test("degraded override keeps additive case defaults", () => {
+    const config = { overrideBuiltinGrep: true };
+    expect(effectiveSignalGrepInput({ pattern: "todo" }, config, false)).toEqual({
+      pattern: "todo",
+    });
+  });
+});
+
+interface MockNotify {
+  message: string;
+  type?: string | undefined;
+}
+
+type CommandHandler = (args: string, ctx: ExtensionCommandContext) => Promise<void>;
+type SessionStartHandler = (event: unknown, ctx: ExtensionContext) => unknown;
+
+function createMockPi(): {
+  pi: ExtensionAPI;
+  toolNames: string[];
+  notifications: MockNotify[];
+  commands: Map<string, CommandHandler>;
+  sessionStartHandlers: SessionStartHandler[];
+} {
+  const toolNames: string[] = [];
+  const notifications: MockNotify[] = [];
+  const commands = new Map<string, CommandHandler>();
+  const sessionStartHandlers: SessionStartHandler[] = [];
+  // Test double: only the API surface this extension actually uses. The single
+  // assertion here replaces seven scattered per-call-site assertions.
+  // oxlint-disable-next-line no-unsafe-type-assertion -- test double covers only the consumed host surface
+  const pi = {
+    registerTool: (tool: { name: string }) => {
+      toolNames.push(tool.name);
+    },
+    registerCommand: (name: string, options: { handler: CommandHandler }) => {
+      commands.set(name, options.handler);
+    },
+    on: (event: string, handler: SessionStartHandler) => {
+      if (event === "session_start") sessionStartHandlers.push(handler);
+    },
+    getAllTools: () => [],
+    exec: async () => ({ code: 0, stdout: "ripgrep 15.2.0\n", stderr: "", killed: false }),
+  } as unknown as ExtensionAPI;
+  return { pi, toolNames, notifications, commands, sessionStartHandlers };
+}
+
+function createContext(
+  notifications: MockNotify[],
+  onReload?: () => Promise<void>,
+): ExtensionCommandContext {
+  // oxlint-disable-next-line no-unsafe-type-assertion -- test double covers only the consumed context surface
+  return {
+    ui: {
+      notify: (text: string, kind?: string) => {
+        notifications.push({ message: text, type: kind });
+      },
+      setStatus: () => {},
+    },
+    reload: onReload ?? (async () => {}),
+  } as unknown as ExtensionCommandContext;
+}
+
+const tempDirs: string[] = [];
+
+async function createAgentDir(withConflict: boolean): Promise<string> {
+  const agentDir = await mkdtemp(join(tmpdir(), "signal-grep-ext-"));
+  tempDirs.push(agentDir);
+  const nodeModules = join(agentDir, "npm", "node_modules");
+  await mkdir(nodeModules, { recursive: true });
+  if (withConflict) {
+    await mkdir(join(nodeModules, "pi-hashline-edit-pro"), { recursive: true });
+  }
+  return agentDir;
+}
+
+afterEach(async () => {
+  const dirs = tempDirs.splice(0, tempDirs.length);
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("Signal Grep extension registration", () => {
+  test("degrades override to additive signal_grep when a conflict package is installed", async () => {
+    const agentDir = await createAgentDir(true);
+    await writeSignalGrepConfig({ overrideBuiltinGrep: true }, agentDir);
+    const configBefore = await readFile(join(agentDir, "signal-grep.json"), "utf8");
+    const harness = createMockPi();
+
+    await registerSignalGrepExtension(harness.pi, { overrideBuiltinGrep: true }, { agentDir });
+
+    expect(harness.toolNames).toEqual(["signal_grep"]);
+    const ctx = createContext(harness.notifications);
+    await Promise.all(
+      harness.sessionStartHandlers.map((handler) =>
+        handler({ type: "session_start", reason: "startup" }, ctx),
+      ),
+    );
+    const degraded = harness.notifications.filter((entry) =>
+      entry.message.includes("pi-hashline-edit-pro"),
+    );
+    expect(degraded.length).toBeGreaterThan(0);
+    expect(degraded[0]?.type).toBe("warning");
+    const configAfter = await readFile(join(agentDir, "signal-grep.json"), "utf8");
+    expect(configAfter).toBe(configBefore);
+  }, 10_000);
+
+  test("keeps the grep override active when no conflict package is installed", async () => {
+    const agentDir = await createAgentDir(false);
+    const harness = createMockPi();
+
+    await registerSignalGrepExtension(harness.pi, { overrideBuiltinGrep: true }, { agentDir });
+
+    expect(harness.toolNames).toEqual(["grep"]);
+    const ctx = createContext(harness.notifications);
+    await Promise.all(
+      harness.sessionStartHandlers.map((handler) =>
+        handler({ type: "session_start", reason: "startup" }, ctx),
+      ),
+    );
+    expect(harness.notifications.some((entry) => entry.type === "warning")).toBe(false);
+  }, 10_000);
+
+  test("degrades safely to additive mode when conflict detection fails", async () => {
+    const agentDir = await createAgentDir(false);
+    const harness = createMockPi();
+
+    await registerSignalGrepExtension(
+      harness.pi,
+      { overrideBuiltinGrep: true },
+      {
+        agentDir,
+        detectConflict: async () => {
+          throw new Error("fs unavailable");
+        },
+      },
+    );
+
+    expect(harness.toolNames).toEqual(["signal_grep"]);
+    const ctx = createContext(harness.notifications);
+    await Promise.all(
+      harness.sessionStartHandlers.map((handler) =>
+        handler({ type: "session_start", reason: "startup" }, ctx),
+      ),
+    );
+    const degraded = harness.notifications.filter((entry) =>
+      entry.message.includes("conflict detection failed"),
+    );
+    expect(degraded.length).toBeGreaterThan(0);
+  }, 10_000);
+
+  test("clears the metrics handoff without enabling metrics when degraded", async () => {
+    const agentDir = await createAgentDir(true);
+    const configPath = join(agentDir, "signal-grep.json");
+    await writeSignalGrepConfig(
+      { overrideBuiltinGrep: true, startMetricsOnNextLoad: true },
+      agentDir,
+    );
+    const harness = createMockPi();
+
+    await registerSignalGrepExtension(
+      harness.pi,
+      { overrideBuiltinGrep: true, startMetricsOnNextLoad: true },
+      { agentDir },
+    );
+    const ctx = createContext(harness.notifications);
+    await Promise.all(
+      harness.sessionStartHandlers.map((handler) =>
+        handler({ type: "session_start", reason: "startup" }, ctx),
+      ),
+    );
+
+    const config = await readSignalGrepConfig(agentDir);
+    expect(config.startMetricsOnNextLoad).toBe(false);
+    expect(
+      harness.notifications.some((entry) => entry.message.includes("Metrics were not enabled")),
+    ).toBe(true);
+    expect(configPath.length).toBeGreaterThan(0);
+  }, 10_000);
+
+  test("refuses to enable metrics through the command when a conflict package is installed", async () => {
+    const agentDir = await createAgentDir(true);
+    const configPath = join(agentDir, "signal-grep.json");
+    await writeSignalGrepConfig({ overrideBuiltinGrep: false }, agentDir);
+    const configBefore = await readFile(configPath, "utf8");
+    const harness = createMockPi();
+
+    await registerSignalGrepExtension(harness.pi, { overrideBuiltinGrep: false }, { agentDir });
+    const metricsCommand = harness.commands.get("signal-grep-metrics");
+    expect(metricsCommand).toBeDefined();
+    const ctx = createContext(harness.notifications);
+    await metricsCommand?.("on", ctx);
+
+    expect(
+      harness.notifications.some((entry) => entry.message.includes("Metrics were not enabled")),
+    ).toBe(true);
+    expect(await readFile(configPath, "utf8")).toBe(configBefore);
+  }, 10_000);
+
+  test("metrics command keeps its existing handoff behavior without conflicts", async () => {
+    const agentDir = await createAgentDir(false);
+    let reloaded = false;
+    const harness = createMockPi();
+
+    await registerSignalGrepExtension(harness.pi, { overrideBuiltinGrep: false }, { agentDir });
+    const metricsCommand = harness.commands.get("signal-grep-metrics");
+    const ctx = createContext(harness.notifications, async () => {
+      reloaded = true;
+    });
+    await metricsCommand?.("on", ctx);
+
+    const config = await readSignalGrepConfig(agentDir);
+    expect(config.overrideBuiltinGrep).toBe(true);
+    expect(config.startMetricsOnNextLoad).toBe(true);
+    expect(reloaded).toBe(true);
+  }, 10_000);
+
+  test("refuses to enable the override through the command when a conflict package is installed", async () => {
+    const agentDir = await createAgentDir(true);
+    const configPath = join(agentDir, "signal-grep.json");
+    await writeSignalGrepConfig({ overrideBuiltinGrep: false }, agentDir);
+    const configBefore = await readFile(configPath, "utf8");
+    const harness = createMockPi();
+
+    await registerSignalGrepExtension(harness.pi, { overrideBuiltinGrep: false }, { agentDir });
+    const overrideCommand = harness.commands.get("signal-grep-override");
+    expect(overrideCommand).toBeDefined();
+    const ctx = createContext(harness.notifications);
+    await overrideCommand?.("on", ctx);
+
+    expect(
+      harness.notifications.some((entry) =>
+        entry.message.includes('owns the public "grep" tool name'),
+      ),
+    ).toBe(true);
+    expect(await readFile(configPath, "utf8")).toBe(configBefore);
+  }, 10_000);
 });


### PR DESCRIPTION
## Summary

Configuring the built-in `grep` override while another extension that registers a public `grep` tool is installed (for example `pi-hashline-edit-pro`) made Pi's extension loader reject the entire extension set at startup with `Tool "grep" conflicts`, requiring `pi -ne` to recover. Signal Grep now detects that situation at load time and degrades to additive `signal_grep` for the session with a visible notice.

## Motivation

Observed live: with `overrideBuiltinGrep: true` and `pi-hashline-edit-pro` installed, Pi refused to start. The existing `grepOverrideConflictSource` check only guarded the `/signal-grep-override on` and `/signal-grep-metrics on` command paths, not registration, and `getAllTools()` cannot see packages that register after Signal Grep loads.

## Public contract

- No tool schema, output, cursor, or search-semantics change.
- New load-time behavior: configured override + installed conflict package → session runs in additive `signal_grep` mode with a warning notice. The config value is never rewritten; removing the conflicting package restores the override on the next load.
- `/signal-grep-metrics on` and the `startMetricsOnNextLoad` handoff now refuse (with a notice) to persist an override that cannot take effect while a conflict is installed.
- `/signal-grep-override on` additionally refuses when a conflict-table package is present in the agent package directory.
- `/signal-grep-health` now reports the effective tool mode, including the degraded reason.
- New exports: `resolveOverrideActive`, `SignalGrepExtensionOptions`; `effectiveSignalGrepInput` gains an optional `overrideActive` parameter (defaults preserve current behavior).

## Design and ownership

- `conflicts.ts` owns the single data table of known grep-owning packages and the agent-directory scan; extending it for future conflicts is a one-line data change.
- `messages.ts` owns templates for human-facing notices; model-facing tool response text is deliberately not routed through it (it is read by the model and stays locale-independent).
- `index.ts` owns mode resolution at registration and threads one `agentDir` test seam through every config write, so tests run against temp directories and never touch the real agent config.

## Validation

- [x] `bun install --frozen-lockfile` — 139 installs across 204 packages (no changes)
- [x] `bun run check` — format, type-aware lint, typecheck, 84 tests (0 fail), Node smoke, benchmark all green
- [x] `bun run pack:check` — pi-plugin-signal-grep-0.4.0.tgz, 28 files

Benchmark output unchanged versus README: compact 33/33 with no extra turn; broad 233 matches, 321-byte first response, 96.7% reduction.

## Negative paths and invariants

- Regression test: degraded session registers `signal_grep` (not `grep`), emits a warning notice naming the conflicting package, and leaves `signal-grep.json` byte-identical.
- Regression test: override stays active (`grep` registered, no warning) when the agent directory contains no conflict package.
- Regression test: if conflict detection itself throws, the extension degrades to additive mode and the notice names the detection failure instead of claiming no conflict.
- Regression test: `startMetricsOnNextLoad` under degradation clears the handoff, refuses metrics, and does not enable the comparison window.
- Regression test: `/signal-grep-metrics on` and `/signal-grep-override on` refuse under conflict and leave the config untouched; without conflicts the metrics handoff behavior is unchanged (writes override + handoff, reloads).
- Isolated end-to-end verification with real Pi using `PI_CODING_AGENT_DIR` temp environments: published 0.4.0 + hashline + override reproduced the exact original `Tool "grep" conflicts` startup failure; the fixed build in the same environment started cleanly and served requests (model replied, exit 0); the fixed build without hashline kept the override active.

## Risks and rollback

- The conflict table is data; an unknown future grep-owning package would still crash (same as 0.4.0) until added to the table — documented in `conflicts.ts`.
- Rollback: revert this commit; no config or session state migrates, so a revert is clean.

## AI provenance

- Authored by ZCode (GLM) in `fix/conflict-degrade`; diff reviewed and validated end-to-end by the AI, including the isolated real-Pi scenarios above.
- Human review of the final diff has not happened yet; maintainer review is required before merge.
- No unverified claims remain in this body; the degraded-mode notice text in a live TUI session was verified via unit-level notify capture, not a manual TUI screenshot.