### PR TITLE
feat: guide hashline editing handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes will be documented in this file. The project follows [Semant
 
 - Context-aware implicit `auto` detail budgets use Pi's reported context remainder: full (2,000 estimated tokens), tight (1,000), or critical (500). Compact complete results still return directly, while explicit limits, `matches`, inspection, and cursor pages retain the default budget.
 - Search details expose `budgetTier`, `contextRemainderPercent`, and `resultTokenBudget` when a context decision is available; tight and critical responses also attribute the adjustment in model-facing text.
+- Installations with `pi-hashline-edit-pro` receive one conditional prompt guideline to obtain hashline-served anchors before editing Signal Grep evidence, without repeating the hint in every result or pretending to share private plugin state.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The command safely persists a user-global setting through a staged file at `~/.p
 /signal-grep-override off
 ```
 
+When `pi-hashline-edit-pro` is installed, Signal Grep adds one system prompt guideline telling the model to obtain served anchors through hashline's `grep` or `read` before editing a location found by `signal_grep`. The hint is not repeated in each search response, does not alter Metrics accounting, and does not claim that Signal Grep can write hashline's private served-state.
 Use `/signal-grep-override status` to inspect the active mode. Override is deliberately opt-in because another extension may also replace `grep`; Pi reports tool collisions at startup.
 
 ## Tool

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -163,6 +163,7 @@ Signal Grep 默认使用附加模式，在 Pi 内置 `grep` 旁注册 `signal_gr
 /signal-grep-override off
 ```
 
+安装 `pi-hashline-edit-pro` 时，Signal Grep 会额外加入一条系统提示，要求模型在编辑 `signal_grep` 找到的位置前，先通过 hashline 的 `grep` 或 `read` 获取 served anchors。该提示不会在每次搜索响应中重复，不会影响 Metrics 计量，也不会声称 Signal Grep 能写入 hashline 的私有 served-state。
 使用 `/signal-grep-override status` 查看当前模式。覆盖功能必须主动开启，因为其他扩展也可能替换 `grep`；发生工具冲突时 Pi 会在启动阶段明确警告。
 
 ## 工具接口

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,6 +45,8 @@ format.ts ─── owns model-facing summary, page, byte, and deduplicated cont
 
 Because Pi's extension loader rejects duplicate `grep` registrations at load time and fails the whole extension set, config intent alone cannot decide the effective tool name. `conflicts.ts` keeps the data table of packages known to register their own public `grep` tool and detects them in the agent package directory on every load. When the override is configured but such a package is installed, the override degrades to additive `signal_grep` for that session with a visible notice, the config value is never rewritten, and removing the conflicting package restores the override on the next load. Metrics enablement requires an actually active override and is refused while degraded. If conflict detection itself fails, the extension degrades to additive mode and names the detection failure instead of treating it as "no conflict".
 
+The same package detection runs in additive mode to compose prompt guidance. When the known owner is `pi-hashline-edit-pro`, `index.ts` adds one model-facing guideline to retrieve served anchors through hashline before editing Signal Grep evidence. This is advisory composition only: Signal Grep neither mutates hashline's private state nor repeats the hint in result text. Detection failure leaves additive search behavior intact and does not fabricate an interoperability claim.
+
 ### Request normalization
 
 `request.ts` is the only authority for defaults and numeric bounds. Internal components receive a normalized `SearchRequest` and do not repeat input validation.

--- a/src/conflicts.ts
+++ b/src/conflicts.ts
@@ -7,7 +7,8 @@ import { join } from "node:path";
  * loader rejects duplicate tool registrations and the whole extension set fails
  * to load. Extend this table as the ecosystem grows; do not add ad hoc checks.
  */
-export const GREP_OWNER_PACKAGES: readonly string[] = ["pi-hashline-edit-pro"];
+export const HASHLINE_PACKAGE = "pi-hashline-edit-pro";
+export const GREP_OWNER_PACKAGES: readonly string[] = [HASHLINE_PACKAGE];
 
 function hasErrorCode(error: unknown, codes: string[]): boolean {
   return error instanceof Error && "code" in error && codes.includes(String(error.code));

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { StringEnum } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { detectGrepOwnerConflict } from "./conflicts.js";
+import { detectGrepOwnerConflict, HASHLINE_PACKAGE } from "./conflicts.js";
 import { readSignalGrepConfig, type SignalGrepConfig, writeSignalGrepConfig } from "./config.js";
 import { resolveContextBudget } from "./context-budget.js";
 import { message } from "./messages.js";
@@ -32,6 +32,24 @@ function formatMetricsStatus(runtime: SignalGrepRuntime, ctx: ExtensionContext):
     negative: (text) => theme.fg("error", theme.bold(text)),
     neutral: (text) => theme.fg("muted", text),
   });
+}
+
+export function signalGrepPromptGuidelines(
+  toolName: "grep" | "signal_grep",
+  grepOwnerPackage?: string,
+): string[] {
+  const guidelines = [
+    `Use ${toolName} for content search instead of unbounded rg output.`,
+    `When ${toolName} returns a summary, narrow with path or use its cursor only when exhaustive detail is required.`,
+    `Use ${toolName} mode=inspect with path and line when a matching location needs its enclosing code block.`,
+    `Treat ${toolName} status=partial as incomplete and narrow the query before drawing conclusions.`,
+  ];
+  if (grepOwnerPackage === HASHLINE_PACKAGE) {
+    guidelines.push(
+      `Before editing a location found by ${toolName}, use ${HASHLINE_PACKAGE}'s grep or read tool to obtain served anchors; ${toolName} evidence is not imported into its edit state.`,
+    );
+  }
+  return guidelines;
 }
 
 const searchSchema = Type.Object({
@@ -107,18 +125,19 @@ export function effectiveSignalGrepInput(
  * degrades to additive "signal_grep" with a visible notice instead. The config
  * value is never rewritten: removing the conflicting package restores the
  * override on the next load.
+ * Detection also runs in additive mode so prompt guidance can describe an
+ * installed grep-owner handoff without changing the effective tool mode.
  */
 export async function resolveOverrideActive(
   config: SignalGrepConfig,
   options: SignalGrepExtensionOptions = {},
 ): Promise<{ overrideActive: boolean; conflict: string | undefined }> {
-  if (!config.overrideBuiltinGrep) return { overrideActive: false, conflict: undefined };
   const fallbackDetect = (): Promise<string | undefined> =>
     detectGrepOwnerConflict(options.agentDir ?? getAgentDir());
   const detect = options.detectConflict ?? fallbackDetect;
   try {
     const conflict = await detect();
-    return { overrideActive: conflict === undefined, conflict };
+    return { overrideActive: config.overrideBuiltinGrep && conflict === undefined, conflict };
   } catch {
     // Fail safe: additive mode always loads cleanly, and the notice names the
     // detection failure instead of pretending no conflict exists.
@@ -147,12 +166,7 @@ export async function registerSignalGrepExtension(
     label: SIGNAL_GREP_LABEL,
     description: SIGNAL_GREP_DESCRIPTION,
     promptSnippet: "Search file contents without flooding context",
-    promptGuidelines: [
-      `Use ${toolName} for content search instead of unbounded rg output.`,
-      `When ${toolName} returns a summary, narrow with path or use its cursor only when exhaustive detail is required.`,
-      `Use ${toolName} mode=inspect with path and line when a matching location needs its enclosing code block.`,
-      `Treat ${toolName} status=partial as incomplete and narrow the query before drawing conclusions.`,
-    ],
+    promptGuidelines: signalGrepPromptGuidelines(toolName, conflict),
     parameters: searchSchema,
 
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -12,6 +12,7 @@ import {
   grepOverrideConflictSource,
   registerSignalGrepExtension,
   signalGrepToolName,
+  signalGrepPromptGuidelines,
 } from "../src/index.js";
 import { readSignalGrepConfig, writeSignalGrepConfig } from "../src/config.js";
 
@@ -57,6 +58,16 @@ describe("Signal Grep tool mode", () => {
       pattern: "todo",
     });
   });
+
+  test("adds one hashline handoff guideline only when its grep-owner package is present", () => {
+    const base = signalGrepPromptGuidelines("signal_grep");
+    const withHashline = signalGrepPromptGuidelines("signal_grep", "pi-hashline-edit-pro");
+
+    expect(base.some((guideline) => guideline.includes("served anchors"))).toBe(false);
+    expect(withHashline).toHaveLength(base.length + 1);
+    expect(withHashline.at(-1)).toContain("served anchors");
+    expect(withHashline.at(-1)).toContain("not imported into its edit state");
+  });
 });
 
 interface MockNotify {
@@ -70,11 +81,13 @@ type SessionStartHandler = (event: unknown, ctx: ExtensionContext) => unknown;
 function createMockPi(): {
   pi: ExtensionAPI;
   toolNames: string[];
+  promptGuidelines: string[][];
   notifications: MockNotify[];
   commands: Map<string, CommandHandler>;
   sessionStartHandlers: SessionStartHandler[];
 } {
   const toolNames: string[] = [];
+  const promptGuidelines: string[][] = [];
   const notifications: MockNotify[] = [];
   const commands = new Map<string, CommandHandler>();
   const sessionStartHandlers: SessionStartHandler[] = [];
@@ -82,8 +95,9 @@ function createMockPi(): {
   // assertion here replaces seven scattered per-call-site assertions.
   // oxlint-disable-next-line no-unsafe-type-assertion -- test double covers only the consumed host surface
   const pi = {
-    registerTool: (tool: { name: string }) => {
+    registerTool: (tool: { name: string; promptGuidelines?: string[] }) => {
       toolNames.push(tool.name);
+      promptGuidelines.push(tool.promptGuidelines ?? []);
     },
     registerCommand: (name: string, options: { handler: CommandHandler }) => {
       commands.set(name, options.handler);
@@ -94,7 +108,14 @@ function createMockPi(): {
     getAllTools: () => [],
     exec: async () => ({ code: 0, stdout: "ripgrep 15.2.0\n", stderr: "", killed: false }),
   } as unknown as ExtensionAPI;
-  return { pi, toolNames, notifications, commands, sessionStartHandlers };
+  return {
+    pi,
+    toolNames,
+    promptGuidelines,
+    notifications,
+    commands,
+    sessionStartHandlers,
+  };
 }
 
 function createContext(
@@ -141,6 +162,7 @@ describe("Signal Grep extension registration", () => {
     await registerSignalGrepExtension(harness.pi, { overrideBuiltinGrep: true }, { agentDir });
 
     expect(harness.toolNames).toEqual(["signal_grep"]);
+    expect(harness.promptGuidelines[0]?.some((line) => line.includes("served anchors"))).toBe(true);
     const ctx = createContext(harness.notifications);
     await Promise.all(
       harness.sessionStartHandlers.map((handler) =>
@@ -156,6 +178,35 @@ describe("Signal Grep extension registration", () => {
     expect(configAfter).toBe(configBefore);
   }, 10_000);
 
+  test("adds hashline handoff guidance in configured additive mode", async () => {
+    const agentDir = await createAgentDir(true);
+    const harness = createMockPi();
+
+    await registerSignalGrepExtension(harness.pi, { overrideBuiltinGrep: false }, { agentDir });
+
+    expect(harness.toolNames).toEqual(["signal_grep"]);
+    expect(harness.promptGuidelines[0]?.some((line) => line.includes("served anchors"))).toBe(true);
+  }, 10_000);
+
+  test("keeps additive registration usable when optional handoff detection fails", async () => {
+    const harness = createMockPi();
+
+    await registerSignalGrepExtension(
+      harness.pi,
+      { overrideBuiltinGrep: false },
+      {
+        detectConflict: async () => {
+          throw new Error("fs unavailable");
+        },
+      },
+    );
+
+    expect(harness.toolNames).toEqual(["signal_grep"]);
+    expect(harness.promptGuidelines[0]?.some((line) => line.includes("served anchors"))).toBe(
+      false,
+    );
+  }, 10_000);
+
   test("keeps the grep override active when no conflict package is installed", async () => {
     const agentDir = await createAgentDir(false);
     const harness = createMockPi();
@@ -163,6 +214,9 @@ describe("Signal Grep extension registration", () => {
     await registerSignalGrepExtension(harness.pi, { overrideBuiltinGrep: true }, { agentDir });
 
     expect(harness.toolNames).toEqual(["grep"]);
+    expect(harness.promptGuidelines[0]?.some((line) => line.includes("served anchors"))).toBe(
+      false,
+    );
     const ctx = createContext(harness.notifications);
     await Promise.all(
       harness.sessionStartHandlers.map((handler) =>


### PR DESCRIPTION
## Summary

When `pi-hashline-edit-pro` is installed, Signal Grep adds one conditional system prompt guideline telling the model to obtain hashline-served anchors before editing a location found by Signal Grep.

## Motivation

Signal Grep can locate evidence but cannot write hashline's private served-state. Without an explicit handoff, the model may attempt an edit with anchors that hashline has never served and waste an avoidable tool turn.

## Public contract

- No tool schema, result text, details, cursor, or search-semantics change.
- The guideline is present only when the known grep-owner package is detected.
- The guideline directs the model to hashline's `grep` or `read` before editing and explicitly avoids claiming private-state interoperability.
- Detection failure leaves additive search behavior usable and does not fabricate the integration hint.

## Design and ownership

- Existing conflict-package detection is reused as the single package-presence source.
- `signalGrepPromptGuidelines` composes one startup guideline; search formatters and Metrics never receive or append it.
- The design is advisory composition, not a compatibility adapter or duplicate served-state store.

## Validation

- [x] `bun install --frozen-lockfile`
- [x] `bun run check`
- [x] `bun run pack:check`
- [ ] Real ripgrep integration behavior was tested when search semantics changed

```text
Search semantics do not change. PR-specific validation passed 94 tests plus
format, type-aware lint, typecheck, Node smoke, benchmark, and pack dry-run.
Final stacked validation passed 101 tests.
```

## Negative paths and invariants

- [ ] No retained match can be silently omitted or duplicated
- [ ] Partial, truncated, expired, cancelled, and failed states remain observable
- [ ] Process and snapshot lifecycle cleanup is covered
- [ ] `.git`, hidden-file, ignore, regex/literal, case, and glob behavior remains intentional
- [x] Not applicable; explain why below

Tests cover package present/absent, additive/override registration, and detection failure. The hint is connected only through `promptGuidelines`; there is no dedicated end-to-end Metrics counter assertion because result text and accounting inputs are structurally untouched.

## Risk and rollback

The only risk is stale guidance if hashline changes its public tool names. Rollback is a clean revert; no config, cursor, Metrics, or persistent state changes.

## Documentation

- [x] English README or docs updated
- [x] Simplified Chinese README updated when user-facing behavior changed
- [x] Changelog updated
- [ ] No documentation change required

## AI provenance

- **AI agent/model family:** GPT-5.6 Sol via Pi; independent reviewer subagent used for final stack review
- **Human final-diff review:** No; maintainer authorized remote submission after AI review
- **Validation executed by AI:** frozen install, LSP, `bun run check`, `bun run pack:check`, final diff review
- **Unverified claims or remaining uncertainty:** No dedicated end-to-end Metrics assertion for the prompt-only path; wiring and existing accounting tests were reviewed

## Final review

- [x] The branch is focused and contains no unrelated changes
- [x] The final diff was reviewed
- [x] No generated artifacts, credentials, private source, or logs are committed
- [x] This PR does not publish, release, or merge itself
