### PR TITLE
feat: localize human-facing controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes will be documented in this file. The project follows [Semant
 - Context-aware implicit `auto` detail budgets use Pi's reported context remainder: full (2,000 estimated tokens), tight (1,000), or critical (500). Compact complete results still return directly, while explicit limits, `matches`, inspection, and cursor pages retain the default budget.
 - Search details expose `budgetTier`, `contextRemainderPercent`, and `resultTokenBudget` when a context decision is available; tight and critical responses also attribute the adjustment in model-facing text.
 - Installations with `pi-hashline-edit-pro` receive one conditional prompt guideline to obtain hashline-served anchors before editing Signal Grep evidence, without repeating the hint in every result or pretending to share private plugin state.
+- Human-facing command descriptions, notifications, health output, and Metrics status/reports support the persisted `locale` values `en` and `zh-CN`; English remains the default for existing configs.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,20 @@ The command safely persists a user-global setting through a staged file at `~/.p
 When `pi-hashline-edit-pro` is installed, Signal Grep adds one system prompt guideline telling the model to obtain served anchors through hashline's `grep` or `read` before editing a location found by `signal_grep`. The hint is not repeated in each search response, does not alter Metrics accounting, and does not claim that Signal Grep can write hashline's private served-state.
 Use `/signal-grep-override status` to inspect the active mode. Override is deliberately opt-in because another extension may also replace `grep`; Pi reports tool collisions at startup.
 
+## Interface language
+
+Human-facing command descriptions, notifications, health output, and Metrics status/report text default to English. To use Simplified Chinese, set `locale` in `~/.pi/agent/signal-grep.json` and restart Pi:
+
+```json
+{
+  "overrideBuiltinGrep": false,
+  "startMetricsOnNextLoad": false,
+  "locale": "zh-CN"
+}
+```
+
+Supported values are `"en"` and `"zh-CN"`. Existing config files without `locale` continue to use English. Signal Grep commands preserve the complete config object when they update override or Metrics handoff state. Search evidence, tool parameters, cursor details, and model-facing prompt guidelines remain language-neutral or English so localization cannot change search semantics or Metrics accounting.
+
 ## Tool
 
 The extension registers one tool: `signal_grep` by default, or `grep` in override mode.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,6 +166,20 @@ Signal Grep 默认使用附加模式，在 Pi 内置 `grep` 旁注册 `signal_gr
 安装 `pi-hashline-edit-pro` 时，Signal Grep 会额外加入一条系统提示，要求模型在编辑 `signal_grep` 找到的位置前，先通过 hashline 的 `grep` 或 `read` 获取 served anchors。该提示不会在每次搜索响应中重复，不会影响 Metrics 计量，也不会声称 Signal Grep 能写入 hashline 的私有 served-state。
 使用 `/signal-grep-override status` 查看当前模式。覆盖功能必须主动开启，因为其他扩展也可能替换 `grep`；发生工具冲突时 Pi 会在启动阶段明确警告。
 
+## 界面语言
+
+面向用户的命令说明、通知、健康检查输出和 Metrics 状态/报告默认使用英文。如需简体中文，请在 `~/.pi/agent/signal-grep.json` 中设置 `locale`，然后重启 Pi：
+
+```json
+{
+  "overrideBuiltinGrep": false,
+  "startMetricsOnNextLoad": false,
+  "locale": "zh-CN"
+}
+```
+
+支持的值为 `"en"` 和 `"zh-CN"`。未包含 `locale` 的现有配置仍使用英文。Signal Grep 命令更新覆盖模式或 Metrics 重载交接状态时会保留完整配置。搜索证据、工具参数、cursor 详情和面向模型的提示保持语言中立或英文，因此本地化不会改变搜索语义或 Metrics 计量。
+
 ## 工具接口
 
 插件默认只注册 `signal_grep`；覆盖模式下只注册 `grep`。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,7 +5,7 @@ Signal Grep is intentionally a composition of single-purpose components. It opti
 ## Data flow
 
 ```text
-config.ts ─── selects additive `signal_grep` or opt-in built-in `grep` override
+config.ts ─── selects tool mode and the human-facing interface locale
     │
     ▼
 conflicts.ts ─ detects installed packages that own the public "grep" tool name
@@ -35,13 +35,13 @@ format.ts ─── owns model-facing summary, page, byte, and deduplicated cont
     └─► metrics.ts ── optionally compares cumulative result text with normal grep
 ```
 
-`index.ts` is the Pi adapter. It defines the schema, registers exactly one Signal Grep tool, registers commands, and wires lifecycle cleanup. `runtime.ts` owns the service/metrics/cursor coordination used by the tool. It contains no search algorithm. Additive mode uses `signal_grep`; explicit override mode uses `grep` and replaces Pi's built-in implementation. When metrics are enabled, `service.ts` derives both Signal Grep and normal-format text from the same snapshot and passes them to `metrics.ts`. `messages.ts` owns the templates for human-facing command and notification text; model-facing tool response text is intentionally not routed through it.
+`index.ts` is the Pi adapter entry point. It defines the schema, registers exactly one Signal Grep tool, and composes the runtime with `extension-controls.ts`. The controls module registers human-facing commands and lifecycle cleanup; it also owns conflict checks performed during command transitions so override and Metrics enablement cannot drift into duplicate policies. `runtime.ts` owns the service/metrics/cursor coordination used by the tool and contains no search algorithm. Additive mode uses `signal_grep`; explicit override mode uses `grep` and replaces Pi's built-in implementation. When metrics are enabled, `service.ts` derives both Signal Grep and normal-format text from the same snapshot and passes them to `metrics.ts`. `messages.ts` is the single catalog for human-facing command and notification text in English and Simplified Chinese. Its typed keys enforce catalog completeness, and message formatting rejects missing parameters or translated placeholder drift. Model-facing tool response text is intentionally not routed through it.
 
 ## Responsibilities
 
 ### Persistent tool mode
 
-`config.ts` owns the user-global `signal-grep.json` contract and staged writes. Missing config means additive mode. A one-shot `startMetricsOnNextLoad` handoff lets `/signal-grep-metrics on` persist the override, reload, clear the handoff, and start session-local Metrics without requiring a second command. Invalid JSON or a mistyped value fails clearly instead of silently changing which public tool owns `grep`. Override commands inspect the active grep source and refuse to persist when another extension already owns it.
+`config.ts` owns the complete user-global `signal-grep.json` contract and staged writes. Missing config means additive mode with the English interface; a legacy config without `locale` also defaults to English. The only accepted locales are `en` and `zh-CN`. A one-shot `startMetricsOnNextLoad` handoff lets `/signal-grep-metrics on` persist the override, reload, clear the handoff, and start session-local Metrics without requiring a second command. Commands update config from the complete validated object, so changing override or handoff state cannot discard locale or another field. Invalid JSON, a mistyped value, an unsupported locale, or an inconsistent handoff fails clearly instead of silently changing behavior. Override commands inspect the active grep source and refuse to persist when another extension already owns it.
 
 Because Pi's extension loader rejects duplicate `grep` registrations at load time and fails the whole extension set, config intent alone cannot decide the effective tool name. `conflicts.ts` keeps the data table of packages known to register their own public `grep` tool and detects them in the agent package directory on every load. When the override is configured but such a package is installed, the override degrades to additive `signal_grep` for that session with a visible notice, the config value is never rewritten, and removing the conflicting package restores the override on the next load. Metrics enablement requires an actually active override and is refused while degraded. If conflict detection itself fails, the extension degrades to additive mode and names the detection failure instead of treating it as "no conflict".
 
@@ -100,7 +100,7 @@ Snapshots are session-local and are cleared at shutdown. Results without a curso
 
 ### Opt-in comparison metrics
 
-`metrics.ts` owns one session-local comparison window, the characters-over-four token estimate, exact byte totals, and compact Status Line/report formatting. It is disabled by default. Every new search contributes one Signal Grep result and one normal-format rendering of the exact same snapshot; tracked cursor pages contribute only their Signal Grep result. Metrics never run a second search, alter model-facing search text, persist state, or transmit data.
+`metrics.ts` owns one session-local comparison window, the characters-over-four token estimate, exact byte totals, and compact Status Line/report formatting. It is disabled by default. Every new search contributes one Signal Grep result and one normal-format rendering of the exact same snapshot; tracked cursor pages contribute only their Signal Grep result. Locale changes only the human-facing labels and prose after accounting is complete. Metrics never run a second search, alter model-facing search text, persist state, or transmit data.
 
 ## Core invariants
 
@@ -116,6 +116,7 @@ Snapshots are session-local and are cleared at shutdown. Results without a curso
 - Disabled metrics render no normal-format baseline and add no status.
 - Metrics never recount a normal baseline for cursor continuation and never hide negative savings.
 - Additive and override modes each register exactly one Signal Grep-owned public tool.
+- Config updates preserve the complete validated object; locale and Metrics handoff state are never dual-written.
 - Compact complete searches return directly; adaptive policy never changes the underlying match set.
 - Context-aware budgeting never downshifts explicit limits, `matches`, inspection, or cursor continuation.
 - A known context adjustment is attributed in structured details; tight and critical adjustments are also explicit in model-facing text.

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,14 +5,18 @@ import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
 const CONFIG_FILE = "signal-grep.json";
 
+export type SignalGrepLocale = "en" | "zh-CN";
+
 export interface SignalGrepConfig {
   overrideBuiltinGrep: boolean;
-  startMetricsOnNextLoad?: boolean;
+  startMetricsOnNextLoad: boolean;
+  locale: SignalGrepLocale;
 }
 
-export const DEFAULT_SIGNAL_GREP_CONFIG: Readonly<Required<SignalGrepConfig>> = {
+export const DEFAULT_SIGNAL_GREP_CONFIG: Readonly<SignalGrepConfig> = {
   overrideBuiltinGrep: false,
   startMetricsOnNextLoad: false,
+  locale: "en",
 };
 
 function hasErrorCode(error: unknown, codes: string[]): boolean {
@@ -23,24 +27,39 @@ function isMissingFile(error: unknown): boolean {
   return hasErrorCode(error, ["ENOENT"]);
 }
 
+interface RawSignalGrepConfig {
+  overrideBuiltinGrep?: unknown;
+  startMetricsOnNextLoad?: unknown;
+  locale?: unknown;
+}
+
+function isRawSignalGrepConfig(value: unknown): value is RawSignalGrepConfig {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function parseConfig(value: unknown, path: string): SignalGrepConfig {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+  if (!isRawSignalGrepConfig(value)) {
     throw new Error(`Invalid Signal Grep config at ${path}: expected a JSON object`);
   }
-  const overrideBuiltinGrep = Reflect.get(value, "overrideBuiltinGrep");
+  const { overrideBuiltinGrep } = value;
   if (overrideBuiltinGrep !== undefined && typeof overrideBuiltinGrep !== "boolean") {
     throw new Error(`Invalid Signal Grep config at ${path}: overrideBuiltinGrep must be boolean`);
   }
-  const startMetricsOnNextLoad = Reflect.get(value, "startMetricsOnNextLoad");
+  const { startMetricsOnNextLoad } = value;
   if (startMetricsOnNextLoad !== undefined && typeof startMetricsOnNextLoad !== "boolean") {
     throw new Error(
       `Invalid Signal Grep config at ${path}: startMetricsOnNextLoad must be boolean`,
     );
   }
+  const { locale } = value;
+  if (locale !== undefined && locale !== "en" && locale !== "zh-CN") {
+    throw new Error(`Invalid Signal Grep config at ${path}: locale must be "en" or "zh-CN"`);
+  }
   const parsed = {
     overrideBuiltinGrep: overrideBuiltinGrep ?? DEFAULT_SIGNAL_GREP_CONFIG.overrideBuiltinGrep,
     startMetricsOnNextLoad:
       startMetricsOnNextLoad ?? DEFAULT_SIGNAL_GREP_CONFIG.startMetricsOnNextLoad,
+    locale: locale ?? DEFAULT_SIGNAL_GREP_CONFIG.locale,
   };
   if (parsed.startMetricsOnNextLoad && !parsed.overrideBuiltinGrep) {
     throw new Error(

--- a/src/conflicts.ts
+++ b/src/conflicts.ts
@@ -10,6 +10,15 @@ import { join } from "node:path";
 export const HASHLINE_PACKAGE = "pi-hashline-edit-pro";
 export const GREP_OWNER_PACKAGES: readonly string[] = [HASHLINE_PACKAGE];
 
+export const CONFLICT_DETECTION_FAILED = "unknown (conflict detection failed)";
+
+export function grepOverrideConflictSource(
+  tools: ReadonlyArray<{ name: string; sourceInfo: { source: string } }>,
+): string | undefined {
+  const source = tools.find((tool) => tool.name === "grep")?.sourceInfo.source;
+  return source && source !== "builtin" ? source : undefined;
+}
+
 function hasErrorCode(error: unknown, codes: string[]): boolean {
   return error instanceof Error && "code" in error && codes.includes(String(error.code));
 }

--- a/src/extension-controls.ts
+++ b/src/extension-controls.ts
@@ -1,0 +1,329 @@
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import {
+  CONFLICT_DETECTION_FAILED,
+  detectGrepOwnerConflict,
+  grepOverrideConflictSource,
+} from "./conflicts.js";
+import { type SignalGrepConfig, writeSignalGrepConfig } from "./config.js";
+import { message } from "./messages.js";
+import { METRICS_STATUS_KEY, SignalGrepRuntime } from "./runtime.js";
+
+export interface SignalGrepControlsOptions {
+  pi: ExtensionAPI;
+  runtime: SignalGrepRuntime;
+  config: SignalGrepConfig;
+  agentDir: string;
+  overrideActive: boolean;
+  degradedOverride: boolean;
+  conflict: string | undefined;
+}
+
+interface GrepConflict {
+  kind: "installed-package" | "active-tool";
+  source: string;
+}
+
+function localizedConflictSource(
+  locale: SignalGrepConfig["locale"],
+  source: string | undefined,
+): string {
+  if (source === CONFLICT_DETECTION_FAILED) return message(locale, "conflictDetectionFailed");
+  return source ?? message(locale, "unknownSource");
+}
+
+function effectiveModeMessage(options: SignalGrepControlsOptions): string {
+  const { config, conflict, degradedOverride, overrideActive } = options;
+  if (overrideActive) return message(config.locale, "healthOverrideMode");
+  if (degradedOverride) {
+    return message(config.locale, "healthDegradedMode", {
+      source: localizedConflictSource(config.locale, conflict),
+    });
+  }
+  return message(config.locale, "healthAdditiveMode");
+}
+
+export function formatMetricsStatus(
+  runtime: SignalGrepRuntime,
+  ctx: ExtensionContext,
+  locale: SignalGrepConfig["locale"],
+): string {
+  const theme = ctx.ui.theme;
+  const highlight = (text: string) => theme.fg("accent", theme.bold(text));
+  return runtime.formatMetricsStatus(
+    {
+      signal: highlight,
+      normal: (text) => theme.fg("muted", text),
+      positive: (text) => theme.fg("success", theme.bold(text)),
+      negative: (text) => theme.fg("error", theme.bold(text)),
+      neutral: (text) => theme.fg("muted", text),
+    },
+    locale,
+  );
+}
+
+async function currentGrepConflict(
+  options: SignalGrepControlsOptions,
+): Promise<GrepConflict | undefined> {
+  const packageConflict = await detectGrepOwnerConflict(options.agentDir);
+  if (packageConflict) return { kind: "installed-package", source: packageConflict };
+  const activeOwner = grepOverrideConflictSource(options.pi.getAllTools());
+  return activeOwner ? { kind: "active-tool", source: activeOwner } : undefined;
+}
+
+function registerHealthCommand(options: SignalGrepControlsOptions): void {
+  const { config, pi, runtime } = options;
+  const { locale } = config;
+  pi.registerCommand("signal-grep-health", {
+    description: message(locale, "commandHealthDescription"),
+    handler: async (_args, ctx) => {
+      const result = await pi.exec("rg", ["--version"], { timeout: 5_000 });
+      if (result.code !== 0) {
+        ctx.ui.notify(
+          message(locale, "healthRipgrepFailure", { error: result.stderr.trim() }),
+          "error",
+        );
+        return;
+      }
+      const version =
+        result.stdout.split("\n")[0] ?? message(locale, "healthUnknownRipgrepVersion");
+      const ctags = await pi.exec("ctags", ["--version"], { timeout: 5_000 });
+      const ctagsVersion =
+        ctags.code === 0 && /Universal Ctags/i.test(ctags.stdout)
+          ? (ctags.stdout.split("\n")[0] ?? message(locale, "healthUnknownCtagsVersion"))
+          : message(locale, "healthCtagsUnavailable");
+      const tools = pi.getAllTools();
+      const searchTools = tools
+        .map((tool) => tool.name)
+        .filter((name) => name === "grep" || name === "signal_grep")
+        .toSorted((left, right) => left.localeCompare(right));
+      const activeGrepOwner =
+        tools.find((tool) => tool.name === "grep")?.sourceInfo.source ??
+        message(locale, "missingSource");
+      ctx.ui.notify(
+        message(locale, "healthReport", {
+          ripgrepVersion: version,
+          structureVersion: ctagsVersion,
+          effectiveMode: effectiveModeMessage(options),
+          searchTools: searchTools.join(", "),
+          activeGrepOwner,
+          snapshots: runtime.snapshotCount,
+          retainedMatches: runtime.storedMatches,
+        }),
+        "info",
+      );
+    },
+  });
+}
+
+function registerClearCommand(options: SignalGrepControlsOptions): void {
+  const { config, pi, runtime } = options;
+  pi.registerCommand("signal-grep-clear", {
+    description: message(config.locale, "commandClearDescription"),
+    handler: (_args, ctx) => {
+      runtime.clear();
+      ctx.ui.notify(message(config.locale, "snapshotsCleared"), "info");
+      return Promise.resolve();
+    },
+  });
+}
+
+async function changeOverride(
+  options: SignalGrepControlsOptions,
+  overrideBuiltinGrep: boolean,
+  ctx: ExtensionCommandContext,
+): Promise<void> {
+  const { agentDir, config } = options;
+  const { locale } = config;
+  if (overrideBuiltinGrep) {
+    const conflict = await currentGrepConflict(options);
+    if (conflict) {
+      const key =
+        conflict.kind === "installed-package" ? "overrideEnableRefused" : "overrideActiveOwner";
+      ctx.ui.notify(message(locale, key, { source: conflict.source }), "error");
+      return;
+    }
+  }
+  await writeSignalGrepConfig(
+    { ...config, overrideBuiltinGrep, startMetricsOnNextLoad: false },
+    agentDir,
+  );
+  ctx.ui.notify(
+    message(locale, overrideBuiltinGrep ? "overrideReloadEnabled" : "overrideReloadDisabled"),
+    "info",
+  );
+  await ctx.reload();
+}
+
+function registerOverrideCommand(options: SignalGrepControlsOptions): void {
+  const { config, pi } = options;
+  const { locale } = config;
+  pi.registerCommand("signal-grep-override", {
+    description: message(locale, "commandOverrideDescription"),
+    handler: async (args, ctx) => {
+      const action = args.trim().toLowerCase();
+      if (action === "status" || action.length === 0) {
+        ctx.ui.notify(
+          message(locale, config.overrideBuiltinGrep ? "overrideEnabled" : "overrideDisabled"),
+          "info",
+        );
+        return;
+      }
+      if (action !== "on" && action !== "off") {
+        ctx.ui.notify(message(locale, "overrideUsage"), "warning");
+        return;
+      }
+      const overrideBuiltinGrep = action === "on";
+      if (overrideBuiltinGrep === config.overrideBuiltinGrep) {
+        ctx.ui.notify(
+          message(
+            locale,
+            overrideBuiltinGrep ? "overrideAlreadyEnabled" : "overrideAlreadyDisabled",
+          ),
+          "info",
+        );
+        return;
+      }
+      await changeOverride(options, overrideBuiltinGrep, ctx);
+    },
+  });
+}
+
+async function enableMetrics(
+  options: SignalGrepControlsOptions,
+  ctx: ExtensionCommandContext,
+): Promise<void> {
+  const { agentDir, config, conflict, degradedOverride, runtime } = options;
+  const { locale } = config;
+  if (runtime.metricsEnabled) {
+    ctx.ui.notify(message(locale, "metricsAlreadyEnabled"), "info");
+    return;
+  }
+  if (degradedOverride) {
+    ctx.ui.notify(
+      message(locale, "metricsRequiresOverride", {
+        source: localizedConflictSource(locale, conflict),
+      }),
+      "warning",
+    );
+    return;
+  }
+  if (!config.overrideBuiltinGrep) {
+    const activeConflict = await currentGrepConflict(options);
+    if (activeConflict) {
+      const key =
+        activeConflict.kind === "installed-package"
+          ? "metricsRequiresOverride"
+          : "metricsActiveOwner";
+      const severity = activeConflict.kind === "installed-package" ? "warning" : "error";
+      ctx.ui.notify(message(locale, key, { source: activeConflict.source }), severity);
+      return;
+    }
+    await writeSignalGrepConfig(
+      { ...config, overrideBuiltinGrep: true, startMetricsOnNextLoad: true },
+      agentDir,
+    );
+    ctx.ui.notify(message(locale, "metricsReloading"), "info");
+    await ctx.reload();
+    return;
+  }
+  runtime.enableMetrics();
+  ctx.ui.setStatus(METRICS_STATUS_KEY, formatMetricsStatus(runtime, ctx, locale));
+  ctx.ui.notify(message(locale, "metricsEnabled"), "info");
+}
+
+function disableMetrics(options: SignalGrepControlsOptions, ctx: ExtensionCommandContext): void {
+  const { config, runtime } = options;
+  if (!runtime.metricsEnabled) {
+    ctx.ui.notify(message(config.locale, "metricsAlreadyDisabled"), "info");
+    return;
+  }
+  const report = runtime.formatMetricsReport(config.locale);
+  runtime.disableMetrics();
+  ctx.ui.setStatus(METRICS_STATUS_KEY, undefined);
+  ctx.ui.notify(report, "info");
+}
+
+function reportMetricsStatus(
+  options: SignalGrepControlsOptions,
+  ctx: ExtensionCommandContext,
+): void {
+  const { config, runtime } = options;
+  ctx.ui.notify(
+    runtime.metricsEnabled
+      ? runtime.formatMetricsReport(config.locale)
+      : message(config.locale, "metricsDisabledStatus"),
+    "info",
+  );
+}
+
+function registerMetricsCommand(options: SignalGrepControlsOptions): void {
+  const { config, pi } = options;
+  pi.registerCommand("signal-grep-metrics", {
+    description: message(config.locale, "commandMetricsDescription"),
+    handler: async (args, ctx) => {
+      const action = args.trim().toLowerCase();
+      if (action === "on") {
+        await enableMetrics(options, ctx);
+        return;
+      }
+      if (action === "off") {
+        disableMetrics(options, ctx);
+        return;
+      }
+      if (action === "status" || action.length === 0) {
+        reportMetricsStatus(options, ctx);
+        return;
+      }
+      ctx.ui.notify(message(config.locale, "metricsUsage"), "warning");
+    },
+  });
+}
+
+function registerLifecycle(options: SignalGrepControlsOptions): void {
+  const { agentDir, config, conflict, degradedOverride, pi, runtime } = options;
+  const { locale } = config;
+  pi.on("session_start", async (_event, ctx) => {
+    if (degradedOverride) {
+      ctx.ui.notify(
+        message(locale, "overrideDegraded", {
+          source: localizedConflictSource(locale, conflict),
+        }),
+        "warning",
+      );
+    }
+    if (!config.startMetricsOnNextLoad) return;
+    await writeSignalGrepConfig(
+      { ...config, overrideBuiltinGrep: true, startMetricsOnNextLoad: false },
+      agentDir,
+    );
+    if (degradedOverride) {
+      ctx.ui.notify(
+        message(locale, "metricsRequiresOverride", {
+          source: localizedConflictSource(locale, conflict),
+        }),
+        "warning",
+      );
+      return;
+    }
+    runtime.enableMetrics();
+    ctx.ui.setStatus(METRICS_STATUS_KEY, formatMetricsStatus(runtime, ctx, locale));
+    ctx.ui.notify(message(locale, "overrideAndMetricsEnabled"), "info");
+  });
+  pi.on("session_shutdown", (_event, ctx) => {
+    runtime.clear();
+    runtime.disableMetrics();
+    ctx.ui.setStatus(METRICS_STATUS_KEY, undefined);
+  });
+}
+
+export function registerSignalGrepControls(options: SignalGrepControlsOptions): void {
+  registerHealthCommand(options);
+  registerClearCommand(options);
+  registerOverrideCommand(options);
+  registerMetricsCommand(options);
+  registerLifecycle(options);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,16 @@
 import { StringEnum } from "@earendil-works/pi-ai";
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { detectGrepOwnerConflict, HASHLINE_PACKAGE } from "./conflicts.js";
-import { readSignalGrepConfig, type SignalGrepConfig, writeSignalGrepConfig } from "./config.js";
+import {
+  CONFLICT_DETECTION_FAILED,
+  detectGrepOwnerConflict,
+  HASHLINE_PACKAGE,
+} from "./conflicts.js";
+export { grepOverrideConflictSource } from "./conflicts.js";
+import { readSignalGrepConfig, type SignalGrepConfig } from "./config.js";
 import { resolveContextBudget } from "./context-budget.js";
-import { message } from "./messages.js";
+import { formatMetricsStatus, registerSignalGrepControls } from "./extension-controls.js";
 import { createRipgrepRunner } from "./rg.js";
 import { createCtagsStructureProvider } from "./structure.js";
 import { METRICS_STATUS_KEY, SignalGrepRuntime } from "./runtime.js";
@@ -20,18 +25,6 @@ export interface SignalGrepExtensionOptions {
   agentDir?: string;
   /** Overrides conflict detection entirely (test seam). */
   detectConflict?: () => Promise<string | undefined>;
-}
-
-function formatMetricsStatus(runtime: SignalGrepRuntime, ctx: ExtensionContext): string {
-  const theme = ctx.ui.theme;
-  const highlight = (text: string) => theme.fg("accent", theme.bold(text));
-  return runtime.formatMetricsStatus({
-    signal: highlight,
-    normal: (text) => theme.fg("muted", text),
-    positive: (text) => theme.fg("success", theme.bold(text)),
-    negative: (text) => theme.fg("error", theme.bold(text)),
-    neutral: (text) => theme.fg("muted", text),
-  });
 }
 
 export function signalGrepPromptGuidelines(
@@ -97,20 +90,15 @@ const searchSchema = Type.Object({
   ),
 });
 
-export function signalGrepToolName(config: SignalGrepConfig): "grep" | "signal_grep" {
-  return config.overrideBuiltinGrep ? "grep" : "signal_grep";
-}
+type OverrideConfig = Pick<SignalGrepConfig, "overrideBuiltinGrep">;
 
-export function grepOverrideConflictSource(
-  tools: ReadonlyArray<{ name: string; sourceInfo: { source: string } }>,
-): string | undefined {
-  const source = tools.find((tool) => tool.name === "grep")?.sourceInfo.source;
-  return source && source !== "builtin" ? source : undefined;
+export function signalGrepToolName(config: OverrideConfig): "grep" | "signal_grep" {
+  return config.overrideBuiltinGrep ? "grep" : "signal_grep";
 }
 
 export function effectiveSignalGrepInput(
   input: SignalGrepInput,
-  config: SignalGrepConfig,
+  config: OverrideConfig,
   overrideActive: boolean = config.overrideBuiltinGrep,
 ): SignalGrepInput {
   if (!overrideActive || input.cursor || input.ignoreCase !== undefined) return input;
@@ -129,7 +117,7 @@ export function effectiveSignalGrepInput(
  * installed grep-owner handoff without changing the effective tool mode.
  */
 export async function resolveOverrideActive(
-  config: SignalGrepConfig,
+  config: OverrideConfig,
   options: SignalGrepExtensionOptions = {},
 ): Promise<{ overrideActive: boolean; conflict: string | undefined }> {
   const fallbackDetect = (): Promise<string | undefined> =>
@@ -141,7 +129,7 @@ export async function resolveOverrideActive(
   } catch {
     // Fail safe: additive mode always loads cleanly, and the notice names the
     // detection failure instead of pretending no conflict exists.
-    return { overrideActive: false, conflict: "unknown (conflict detection failed)" };
+    return { overrideActive: false, conflict: CONFLICT_DETECTION_FAILED };
   }
 }
 
@@ -160,6 +148,7 @@ export async function registerSignalGrepExtension(
   const { overrideActive, conflict } = await resolveOverrideActive(config, options);
   const degradedOverride = config.overrideBuiltinGrep && !overrideActive;
   const toolName = overrideActive ? "grep" : "signal_grep";
+  const { locale } = config;
 
   pi.registerTool({
     name: toolName,
@@ -177,7 +166,7 @@ export async function registerSignalGrepExtension(
         resolveContextBudget(ctx.getContextUsage()),
       );
       if (runtime.metricsEnabled) {
-        ctx.ui.setStatus(METRICS_STATUS_KEY, formatMetricsStatus(runtime, ctx));
+        ctx.ui.setStatus(METRICS_STATUS_KEY, formatMetricsStatus(runtime, ctx, locale));
       }
 
       return {
@@ -187,216 +176,14 @@ export async function registerSignalGrepExtension(
     },
   });
 
-  pi.registerCommand("signal-grep-health", {
-    description: "Show ripgrep, structure-provider availability, and in-memory snapshot usage",
-    handler: async (_args, ctx) => {
-      const result = await pi.exec("rg", ["--version"], { timeout: 5_000 });
-      if (result.code !== 0) {
-        ctx.ui.notify(`Signal Grep cannot run ripgrep: ${result.stderr.trim()}`, "error");
-        return;
-      }
-      const version = result.stdout.split("\n")[0] ?? "ripgrep (unknown version)";
-      const ctags = await pi.exec("ctags", ["--version"], { timeout: 5_000 });
-      const ctagsVersion =
-        ctags.code === 0 && /Universal Ctags/i.test(ctags.stdout)
-          ? (ctags.stdout.split("\n")[0] ?? "Universal Ctags (unknown version)")
-          : "Universal Ctags unavailable";
-      const tools = pi.getAllTools();
-      const searchTools = tools
-        .map((tool) => tool.name)
-        .filter((name) => name === "grep" || name === "signal_grep")
-        .toSorted();
-      const activeGrepOwner =
-        tools.find((tool) => tool.name === "grep")?.sourceInfo.source ?? "missing";
-      const effectiveMode = overrideActive
-        ? "override built-in grep"
-        : degradedOverride
-          ? message("healthDegradedMode", { source: conflict ?? "unknown" })
-          : "additive signal_grep";
-      ctx.ui.notify(
-        `${version}\nStructure provider: ${ctagsVersion}\nTool mode (effective): ${effectiveMode}\nSearch tools: ${searchTools.join(", ")}\nActive grep owner: ${activeGrepOwner}\nSnapshots: ${runtime.snapshotCount}\nRetained matches: ${runtime.storedMatches}`,
-        "info",
-      );
-    },
-  });
-
-  pi.registerCommand("signal-grep-clear", {
-    description: "Clear all in-memory Signal Grep snapshots and invalidate their cursors",
-    handler: async (_args, ctx) => {
-      runtime.clear();
-      ctx.ui.notify("Signal Grep snapshots cleared", "info");
-    },
-  });
-
-  pi.registerCommand("signal-grep-override", {
-    description: "Enable, disable, or inspect the persistent built-in grep override",
-    handler: async (args, ctx) => {
-      const action = args.trim().toLowerCase();
-      if (action === "status" || action.length === 0) {
-        ctx.ui.notify(
-          `Signal Grep override is ${config.overrideBuiltinGrep ? "enabled" : "disabled"}.`,
-          "info",
-        );
-        return;
-      }
-      if (action !== "on" && action !== "off") {
-        ctx.ui.notify("Usage: /signal-grep-override on|off|status", "warning");
-        return;
-      }
-
-      const overrideBuiltinGrep = action === "on";
-      if (overrideBuiltinGrep === config.overrideBuiltinGrep) {
-        ctx.ui.notify(
-          `Signal Grep override is already ${overrideBuiltinGrep ? "enabled" : "disabled"}.`,
-          "info",
-        );
-        return;
-      }
-
-      if (overrideBuiltinGrep) {
-        const packageConflict = await detectGrepOwnerConflict(agentDir);
-        if (packageConflict) {
-          ctx.ui.notify(message("overrideEnableRefused", { source: packageConflict }), "error");
-          return;
-        }
-        const conflictSource = grepOverrideConflictSource(pi.getAllTools());
-        if (conflictSource) {
-          ctx.ui.notify(
-            `Cannot enable Signal Grep override because grep is already owned by ${conflictSource}.`,
-            "error",
-          );
-          return;
-        }
-      }
-
-      await writeSignalGrepConfig(
-        {
-          overrideBuiltinGrep,
-          startMetricsOnNextLoad: false,
-        },
-        agentDir,
-      );
-      ctx.ui.notify(
-        `Signal Grep override ${overrideBuiltinGrep ? "enabled" : "disabled"}; reloading tools.`,
-        "info",
-      );
-      await ctx.reload();
-    },
-  });
-
-  pi.registerCommand("signal-grep-metrics", {
-    description: "Toggle or inspect cumulative Signal Grep versus normal grep token estimates",
-    handler: async (args, ctx) => {
-      const action = args.trim().toLowerCase();
-      if (action === "on") {
-        if (runtime.metricsEnabled) {
-          ctx.ui.notify("Signal Grep metrics are already enabled", "info");
-          return;
-        }
-        if (degradedOverride) {
-          ctx.ui.notify(
-            message("metricsRequiresOverride", { source: conflict ?? "unknown" }),
-            "warning",
-          );
-          return;
-        }
-        if (!config.overrideBuiltinGrep) {
-          const packageConflict = await detectGrepOwnerConflict(agentDir);
-          if (packageConflict) {
-            ctx.ui.notify(
-              message("metricsRequiresOverride", { source: packageConflict }),
-              "warning",
-            );
-            return;
-          }
-          const conflictSource = grepOverrideConflictSource(pi.getAllTools());
-          if (conflictSource) {
-            ctx.ui.notify(
-              `Signal Grep metrics cannot start because grep is already owned by ${conflictSource}.`,
-              "error",
-            );
-            return;
-          }
-          await writeSignalGrepConfig(
-            {
-              overrideBuiltinGrep: true,
-              startMetricsOnNextLoad: true,
-            },
-            agentDir,
-          );
-          ctx.ui.notify(
-            "Enabling the grep override and reloading before Signal Grep metrics start.",
-            "info",
-          );
-          await ctx.reload();
-          return;
-        }
-        runtime.enableMetrics();
-        ctx.ui.setStatus(METRICS_STATUS_KEY, formatMetricsStatus(runtime, ctx));
-        ctx.ui.notify(
-          "Signal Grep metrics enabled. Every successful Pi grep call will be compared from one shared snapshot.",
-          "info",
-        );
-        return;
-      }
-
-      if (action === "off") {
-        if (!runtime.metricsEnabled) {
-          ctx.ui.notify("Signal Grep metrics are already disabled", "info");
-          return;
-        }
-        const report = runtime.formatMetricsReport();
-        runtime.disableMetrics();
-        ctx.ui.setStatus(METRICS_STATUS_KEY, undefined);
-        ctx.ui.notify(report, "info");
-        return;
-      }
-
-      if (action === "status" || action.length === 0) {
-        ctx.ui.notify(
-          runtime.metricsEnabled
-            ? runtime.formatMetricsReport()
-            : "Signal Grep metrics are disabled. Use /signal-grep-metrics on to enable the grep override if needed and start a new comparison window.",
-          "info",
-        );
-        return;
-      }
-
-      ctx.ui.notify("Usage: /signal-grep-metrics on|off|status", "warning");
-    },
-  });
-
-  pi.on("session_start", async (_event, ctx) => {
-    if (degradedOverride) {
-      ctx.ui.notify(message("overrideDegraded", { source: conflict ?? "unknown" }), "warning");
-    }
-    if (!config.startMetricsOnNextLoad) return;
-    await writeSignalGrepConfig(
-      {
-        overrideBuiltinGrep: true,
-        startMetricsOnNextLoad: false,
-      },
-      agentDir,
-    );
-    if (degradedOverride) {
-      ctx.ui.notify(
-        message("metricsRequiresOverride", { source: conflict ?? "unknown" }),
-        "warning",
-      );
-      return;
-    }
-    runtime.enableMetrics();
-    ctx.ui.setStatus(METRICS_STATUS_KEY, formatMetricsStatus(runtime, ctx));
-    ctx.ui.notify(
-      "Signal Grep override and metrics enabled. Every successful Pi grep call will be compared.",
-      "info",
-    );
-  });
-
-  pi.on("session_shutdown", async (_event, ctx) => {
-    runtime.clear();
-    runtime.disableMetrics();
-    ctx.ui.setStatus(METRICS_STATUS_KEY, undefined);
+  registerSignalGrepControls({
+    pi,
+    runtime,
+    config,
+    agentDir,
+    overrideActive,
+    degradedOverride,
+    conflict,
   });
 }
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,33 +1,129 @@
-/**
- * Templates for human-facing Signal Grep messages: command output, status line,
- * and notifications. Tool response text is intentionally NOT routed through
- * this module — it is read by the model and stays in English regardless of any
- * future locale setting. Structured `details` fields are protocol constants and
- * are never localized.
- */
+import type { SignalGrepLocale } from "./config.js";
+
 const EN = {
+  commandHealthDescription:
+    "Show ripgrep, structure-provider availability, and in-memory snapshot usage",
+  healthRipgrepFailure: "Signal Grep cannot run ripgrep: {error}",
+  healthUnknownRipgrepVersion: "ripgrep (unknown version)",
+  healthUnknownCtagsVersion: "Universal Ctags (unknown version)",
+  healthCtagsUnavailable: "Universal Ctags unavailable",
+  healthOverrideMode: "override built-in grep",
+  healthAdditiveMode: "additive signal_grep",
+  healthDegradedMode: 'degraded to additive "signal_grep" (conflict: {source})',
+  healthReport:
+    "{ripgrepVersion}\nStructure provider: {structureVersion}\nTool mode (effective): {effectiveMode}\nSearch tools: {searchTools}\nActive grep owner: {activeGrepOwner}\nSnapshots: {snapshots}\nRetained matches: {retainedMatches}",
+  commandClearDescription: "Clear all in-memory Signal Grep snapshots and invalidate their cursors",
+  snapshotsCleared: "Signal Grep snapshots cleared",
+  commandOverrideDescription: "Enable, disable, or inspect the persistent built-in grep override",
+  overrideEnabled: "Signal Grep override is enabled.",
+  overrideDisabled: "Signal Grep override is disabled.",
+  overrideUsage: "Usage: /signal-grep-override on|off|status",
+  overrideAlreadyEnabled: "Signal Grep override is already enabled.",
+  overrideAlreadyDisabled: "Signal Grep override is already disabled.",
+  overrideEnableRefused:
+    'Cannot enable Signal Grep override: "{source}" is installed and owns the public "grep" tool name. ' +
+    'Remove it first, or keep using additive "signal_grep".',
+  overrideActiveOwner:
+    "Cannot enable Signal Grep override because grep is already owned by {source}.",
+  overrideReloadEnabled: "Signal Grep override enabled; reloading tools.",
+  overrideReloadDisabled: "Signal Grep override disabled; reloading tools.",
   overrideDegraded:
     'Signal Grep override is enabled in config, but "grep" is owned by {source}. ' +
     'Loading additively as "signal_grep" for this session. ' +
     'Remove {source} to restore the override, or set "overrideBuiltinGrep": false to keep additive mode.',
+  commandMetricsDescription:
+    "Toggle or inspect cumulative Signal Grep versus normal grep token estimates",
+  metricsAlreadyEnabled: "Signal Grep metrics are already enabled",
   metricsRequiresOverride:
     'Signal Grep metrics require the built-in grep override, but "grep" is owned by {source}. ' +
     "Metrics were not enabled.",
-  overrideEnableRefused:
-    'Cannot enable Signal Grep override: "{source}" is installed and owns the public "grep" tool name. ' +
-    'Remove it first, or keep using additive "signal_grep".',
-  healthDegradedMode: 'degraded to additive "signal_grep" (conflict: {source})',
+  metricsActiveOwner: "Signal Grep metrics cannot start because grep is already owned by {source}.",
+  metricsReloading: "Enabling the grep override and reloading before Signal Grep metrics start.",
+  metricsEnabled:
+    "Signal Grep metrics enabled. Every successful Pi grep call will be compared from one shared snapshot.",
+  metricsAlreadyDisabled: "Signal Grep metrics are already disabled",
+  metricsDisabledStatus:
+    "Signal Grep metrics are disabled. Use /signal-grep-metrics on to enable the grep override if needed and start a new comparison window.",
+  metricsUsage: "Usage: /signal-grep-metrics on|off|status",
+  overrideAndMetricsEnabled:
+    "Signal Grep override and metrics enabled. Every successful Pi grep call will be compared.",
+  conflictDetectionFailed: "unknown (conflict detection failed)",
+  missingSource: "missing",
+  unknownSource: "unknown",
 } as const;
 
 export type MessageKey = keyof typeof EN;
-export type MessageParams = Readonly<Record<string, string>>;
+export type MessageParams = Readonly<Record<string, string | number>>;
+type MessageCatalog = { [K in MessageKey]: string };
 
-export function message(key: MessageKey, params?: MessageParams): string {
-  let text: string = EN[key];
-  if (params) {
-    for (const [name, value] of Object.entries(params)) {
-      text = text.replaceAll(`{${name}}`, value);
-    }
+const ZH_CN: MessageCatalog = {
+  commandHealthDescription: "显示 ripgrep、结构提供器可用性和内存快照用量",
+  healthRipgrepFailure: "Signal Grep 无法运行 ripgrep：{error}",
+  healthUnknownRipgrepVersion: "ripgrep（版本未知）",
+  healthUnknownCtagsVersion: "Universal Ctags（版本未知）",
+  healthCtagsUnavailable: "Universal Ctags 不可用",
+  healthOverrideMode: "覆盖内置 grep",
+  healthAdditiveMode: "附加 signal_grep",
+  healthDegradedMode: "已降级为附加 signal_grep（冲突：{source}）",
+  healthReport:
+    "{ripgrepVersion}\n结构提供器：{structureVersion}\n工具模式（实际）：{effectiveMode}\n搜索工具：{searchTools}\n当前 grep 所有者：{activeGrepOwner}\n快照数：{snapshots}\n保留匹配数：{retainedMatches}",
+  commandClearDescription: "清空所有内存 Signal Grep 快照并使其 cursor 失效",
+  snapshotsCleared: "Signal Grep 快照已清空",
+  commandOverrideDescription: "启用、停用或查看持久化的内置 grep 覆盖",
+  overrideEnabled: "Signal Grep 覆盖已启用。",
+  overrideDisabled: "Signal Grep 覆盖已停用。",
+  overrideUsage: "用法：/signal-grep-override on|off|status",
+  overrideAlreadyEnabled: "Signal Grep 覆盖已经启用。",
+  overrideAlreadyDisabled: "Signal Grep 覆盖已经停用。",
+  overrideEnableRefused:
+    "无法启用 Signal Grep 覆盖：已安装的“{source}”拥有公开工具名“grep”。" +
+    "请先移除该包，或继续使用附加的 signal_grep。",
+  overrideActiveOwner: "无法启用 Signal Grep 覆盖，因为 grep 已由 {source} 持有。",
+  overrideReloadEnabled: "Signal Grep 覆盖已启用；正在重新加载工具。",
+  overrideReloadDisabled: "Signal Grep 覆盖已停用；正在重新加载工具。",
+  overrideDegraded:
+    "Signal Grep 配置已启用覆盖，但 grep 由 {source} 持有。" +
+    "本会话将以附加的 signal_grep 加载。" +
+    "移除 {source} 可在下次加载时恢复覆盖；也可将 overrideBuiltinGrep 设为 false 继续使用附加模式。",
+  commandMetricsDescription: "切换或查看 Signal Grep 与普通 grep 的累计 Token 估算对比",
+  metricsAlreadyEnabled: "Signal Grep Metrics 已经启用",
+  metricsRequiresOverride:
+    "Signal Grep Metrics 需要覆盖内置 grep，但 grep 由 {source} 持有。Metrics 未启用。",
+  metricsActiveOwner: "Signal Grep Metrics 无法启动，因为 grep 已由 {source} 持有。",
+  metricsReloading: "正在启用 grep 覆盖并重新加载，之后将启动 Signal Grep Metrics。",
+  metricsEnabled: "Signal Grep Metrics 已启用。每次成功的 Pi grep 调用都会基于同一快照进行对比。",
+  metricsAlreadyDisabled: "Signal Grep Metrics 已经停用",
+  metricsDisabledStatus:
+    "Signal Grep Metrics 已停用。如有需要，请使用 /signal-grep-metrics on 启用 grep 覆盖并开始新的对比区间。",
+  metricsUsage: "用法：/signal-grep-metrics on|off|status",
+  overrideAndMetricsEnabled:
+    "Signal Grep 覆盖和 Metrics 已启用。每次成功的 Pi grep 调用都会参与对比。",
+  conflictDetectionFailed: "未知（冲突检测失败）",
+  missingSource: "缺失",
+  unknownSource: "未知",
+};
+
+function placeholders(template: string): string[] {
+  return [...template.matchAll(/\{([A-Za-z][A-Za-z0-9]*)\}/g)]
+    .map((match) => match[1] ?? "")
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+const CATALOGS: Readonly<Record<SignalGrepLocale, MessageCatalog>> = {
+  en: EN,
+  "zh-CN": ZH_CN,
+};
+
+export function message(locale: SignalGrepLocale, key: MessageKey, params?: MessageParams): string {
+  let text = CATALOGS[locale][key];
+  const required = placeholders(text);
+  if (placeholders(EN[key]).join("\0") !== required.join("\0")) {
+    throw new Error(`Signal Grep message placeholders differ for: ${key}`);
+  }
+  for (const name of required) {
+    const value = params?.[name];
+    if (value === undefined) throw new Error(`Missing Signal Grep message parameter: ${name}`);
+    text = text.replaceAll(`{${name}}`, String(value));
   }
   return text;
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,3 +1,4 @@
+import type { SignalGrepLocale } from "./config.js";
 import { ESTIMATED_CHARACTERS_PER_TOKEN } from "./types.js";
 
 export const METRICS_STATUS_KEY = "signal-grep-metrics";
@@ -97,26 +98,36 @@ export class SearchMetrics {
     return { ...this.#snapshot };
   }
 
-  formatStatus(styles: MetricsStatusStyles = plainMetricsStatusStyles): string {
+  formatStatus(
+    styles: MetricsStatusStyles = plainMetricsStatusStyles,
+    locale: SignalGrepLocale = "en",
+  ): string {
     const snapshot = this.snapshot;
     const result = comparison(snapshot);
     const delta = `${result.improved ? "↓" : "↑"} ${formatTokens(Math.abs(result.difference))} · ${result.percentage.toFixed(1)}%`;
-    const deltaStyle =
-      snapshot.normalTokens === 0 || result.difference === 0
-        ? styles.neutral
-        : result.improved
-          ? styles.positive
-          : styles.negative;
+    let deltaStyle: MetricsStatusStyles["neutral"];
+    if (snapshot.normalTokens === 0 || result.difference === 0) {
+      deltaStyle = styles.neutral;
+    } else if (result.improved) {
+      deltaStyle = styles.positive;
+    } else {
+      deltaStyle = styles.negative;
+    }
+    const normalLabel = locale === "zh-CN" ? "常规" : "NORMAL";
     return [
       styles.signal(`[ SG ${formatTokens(snapshot.signalTokens)} ]`),
-      styles.normal(`[ NORMAL ${formatTokens(snapshot.normalTokens)} ]`),
+      styles.normal(`[ ${normalLabel} ${formatTokens(snapshot.normalTokens)} ]`),
       deltaStyle(`[ ${delta} ]`),
     ].join("  ");
   }
 
-  formatReport(): string {
+  formatReport(locale: SignalGrepLocale = "en"): string {
     const snapshot = this.snapshot;
     const result = comparison(snapshot);
+    if (locale === "zh-CN") {
+      const outcome = result.improved ? "节省" : "额外使用";
+      return `Signal Grep Metrics：SG ${formatTokens(snapshot.signalTokens)} 个估算 Token（${formatBytes(snapshot.signalBytes)}）/ 常规 ${formatTokens(snapshot.normalTokens)}（${formatBytes(snapshot.normalBytes)}）· ${snapshot.searches} 次搜索和 ${snapshot.cursorPages} 个 cursor 页面共${outcome} ${formatTokens(Math.abs(result.difference))}（${result.percentage.toFixed(1)}%）。`;
+    }
     const outcome = result.improved ? "saved" : "used an additional";
     return `Signal Grep metrics: SG ${formatTokens(snapshot.signalTokens)} estimated tokens (${formatBytes(snapshot.signalBytes)}) / normal ${formatTokens(snapshot.normalTokens)} (${formatBytes(snapshot.normalBytes)}) · ${outcome} ${formatTokens(Math.abs(result.difference))} (${result.percentage.toFixed(1)}%) across ${snapshot.searches} searches and ${snapshot.cursorPages} cursor pages.`;
   }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,3 +1,4 @@
+import type { SignalGrepLocale } from "./config.js";
 import {
   METRICS_STATUS_KEY,
   type MetricsSnapshot,
@@ -60,12 +61,12 @@ export class SignalGrepRuntime {
     return this.#metrics.snapshot;
   }
 
-  formatMetricsStatus(styles?: MetricsStatusStyles): string {
-    return this.#metrics.formatStatus(styles);
+  formatMetricsStatus(styles?: MetricsStatusStyles, locale: SignalGrepLocale = "en"): string {
+    return this.#metrics.formatStatus(styles, locale);
   }
 
-  formatMetricsReport(): string {
-    return this.#metrics.formatReport();
+  formatMetricsReport(locale: SignalGrepLocale = "en"): string {
+    return this.#metrics.formatReport(locale);
   }
 
   clear(): void {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -26,39 +26,87 @@ describe("Signal Grep config", () => {
     expect(await readSignalGrepConfig(await agentDir())).toEqual({
       overrideBuiltinGrep: false,
       startMetricsOnNextLoad: false,
+      locale: "en",
     });
   });
 
   test("persists, replaces, and reads override mode through a staged file", async () => {
     const dir = await agentDir();
-    await writeSignalGrepConfig({ overrideBuiltinGrep: true }, dir);
+    await writeSignalGrepConfig(
+      { overrideBuiltinGrep: true, startMetricsOnNextLoad: false, locale: "en" },
+      dir,
+    );
     expect(await readSignalGrepConfig(dir)).toEqual({
       overrideBuiltinGrep: true,
       startMetricsOnNextLoad: false,
+      locale: "en",
     });
 
-    await writeSignalGrepConfig({ overrideBuiltinGrep: false }, dir);
+    await writeSignalGrepConfig(
+      { overrideBuiltinGrep: false, startMetricsOnNextLoad: false, locale: "en" },
+      dir,
+    );
     expect(await readSignalGrepConfig(dir)).toEqual({
       overrideBuiltinGrep: false,
       startMetricsOnNextLoad: false,
+      locale: "en",
     });
     expect(JSON.parse(await readFile(signalGrepConfigPath(dir), "utf8"))).toEqual({
       overrideBuiltinGrep: false,
+      startMetricsOnNextLoad: false,
+      locale: "en",
     });
   });
 
   test("persists the one-shot metrics handoff across reload", async () => {
     const dir = await agentDir();
-    await writeSignalGrepConfig({ overrideBuiltinGrep: true, startMetricsOnNextLoad: true }, dir);
+    await writeSignalGrepConfig(
+      { overrideBuiltinGrep: true, startMetricsOnNextLoad: true, locale: "zh-CN" },
+      dir,
+    );
     expect(await readSignalGrepConfig(dir)).toEqual({
       overrideBuiltinGrep: true,
       startMetricsOnNextLoad: true,
+      locale: "zh-CN",
     });
+  });
+
+  test("defaults locale for legacy config files that predate localization", async () => {
+    const dir = await agentDir();
+    await mkdir(dir, { recursive: true });
+    await writeFile(signalGrepConfigPath(dir), '{"overrideBuiltinGrep":true}', "utf8");
+    expect(await readSignalGrepConfig(dir)).toEqual({
+      overrideBuiltinGrep: true,
+      startMetricsOnNextLoad: false,
+      locale: "en",
+    });
+  });
+
+  test("rejects unsupported locales instead of silently choosing a language", async () => {
+    const dir = await agentDir();
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      signalGrepConfigPath(dir),
+      '{"overrideBuiltinGrep":false,"locale":"fr"}',
+      "utf8",
+    );
+    let failure: unknown;
+    try {
+      await readSignalGrepConfig(dir);
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure instanceof Error ? failure.message : "").toContain(
+      'locale must be "en" or "zh-CN"',
+    );
   });
 
   test("rejects malformed or mistyped config instead of silently changing tool mode", async () => {
     const dir = await agentDir();
-    await writeSignalGrepConfig({ overrideBuiltinGrep: false }, dir);
+    await writeSignalGrepConfig(
+      { overrideBuiltinGrep: false, startMetricsOnNextLoad: false, locale: "en" },
+      dir,
+    );
     await writeFile(signalGrepConfigPath(dir), "{", "utf8");
     let malformed: unknown;
     try {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -14,7 +14,16 @@ import {
   signalGrepToolName,
   signalGrepPromptGuidelines,
 } from "../src/index.js";
-import { readSignalGrepConfig, writeSignalGrepConfig } from "../src/config.js";
+import {
+  DEFAULT_SIGNAL_GREP_CONFIG,
+  readSignalGrepConfig,
+  type SignalGrepConfig,
+  writeSignalGrepConfig,
+} from "../src/config.js";
+
+function testConfig(overrides: Partial<SignalGrepConfig>): SignalGrepConfig {
+  return { ...DEFAULT_SIGNAL_GREP_CONFIG, ...overrides };
+}
 
 describe("Signal Grep tool mode", () => {
   test("keeps additive signal_grep as the safe default", () => {
@@ -155,11 +164,13 @@ afterEach(async () => {
 describe("Signal Grep extension registration", () => {
   test("degrades override to additive signal_grep when a conflict package is installed", async () => {
     const agentDir = await createAgentDir(true);
-    await writeSignalGrepConfig({ overrideBuiltinGrep: true }, agentDir);
+    await writeSignalGrepConfig(testConfig({ overrideBuiltinGrep: true }), agentDir);
     const configBefore = await readFile(join(agentDir, "signal-grep.json"), "utf8");
     const harness = createMockPi();
 
-    await registerSignalGrepExtension(harness.pi, { overrideBuiltinGrep: true }, { agentDir });
+    await registerSignalGrepExtension(harness.pi, testConfig({ overrideBuiltinGrep: true }), {
+      agentDir,
+    });
 
     expect(harness.toolNames).toEqual(["signal_grep"]);
     expect(harness.promptGuidelines[0]?.some((line) => line.includes("served anchors"))).toBe(true);
@@ -182,7 +193,9 @@ describe("Signal Grep extension registration", () => {
     const agentDir = await createAgentDir(true);
     const harness = createMockPi();
 
-    await registerSignalGrepExtension(harness.pi, { overrideBuiltinGrep: false }, { agentDir });
+    await registerSignalGrepExtension(harness.pi, testConfig({ overrideBuiltinGrep: false }), {
+      agentDir,
+    });
 
     expect(harness.toolNames).toEqual(["signal_grep"]);
     expect(harness.promptGuidelines[0]?.some((line) => line.includes("served anchors"))).toBe(true);
@@ -191,15 +204,11 @@ describe("Signal Grep extension registration", () => {
   test("keeps additive registration usable when optional handoff detection fails", async () => {
     const harness = createMockPi();
 
-    await registerSignalGrepExtension(
-      harness.pi,
-      { overrideBuiltinGrep: false },
-      {
-        detectConflict: async () => {
-          throw new Error("fs unavailable");
-        },
+    await registerSignalGrepExtension(harness.pi, testConfig({ overrideBuiltinGrep: false }), {
+      detectConflict: async () => {
+        throw new Error("fs unavailable");
       },
-    );
+    });
 
     expect(harness.toolNames).toEqual(["signal_grep"]);
     expect(harness.promptGuidelines[0]?.some((line) => line.includes("served anchors"))).toBe(
@@ -211,7 +220,9 @@ describe("Signal Grep extension registration", () => {
     const agentDir = await createAgentDir(false);
     const harness = createMockPi();
 
-    await registerSignalGrepExtension(harness.pi, { overrideBuiltinGrep: true }, { agentDir });
+    await registerSignalGrepExtension(harness.pi, testConfig({ overrideBuiltinGrep: true }), {
+      agentDir,
+    });
 
     expect(harness.toolNames).toEqual(["grep"]);
     expect(harness.promptGuidelines[0]?.some((line) => line.includes("served anchors"))).toBe(
@@ -230,16 +241,12 @@ describe("Signal Grep extension registration", () => {
     const agentDir = await createAgentDir(false);
     const harness = createMockPi();
 
-    await registerSignalGrepExtension(
-      harness.pi,
-      { overrideBuiltinGrep: true },
-      {
-        agentDir,
-        detectConflict: async () => {
-          throw new Error("fs unavailable");
-        },
+    await registerSignalGrepExtension(harness.pi, testConfig({ overrideBuiltinGrep: true }), {
+      agentDir,
+      detectConflict: async () => {
+        throw new Error("fs unavailable");
       },
-    );
+    });
 
     expect(harness.toolNames).toEqual(["signal_grep"]);
     const ctx = createContext(harness.notifications);
@@ -258,14 +265,14 @@ describe("Signal Grep extension registration", () => {
     const agentDir = await createAgentDir(true);
     const configPath = join(agentDir, "signal-grep.json");
     await writeSignalGrepConfig(
-      { overrideBuiltinGrep: true, startMetricsOnNextLoad: true },
+      testConfig({ overrideBuiltinGrep: true, startMetricsOnNextLoad: true }),
       agentDir,
     );
     const harness = createMockPi();
 
     await registerSignalGrepExtension(
       harness.pi,
-      { overrideBuiltinGrep: true, startMetricsOnNextLoad: true },
+      testConfig({ overrideBuiltinGrep: true, startMetricsOnNextLoad: true }),
       { agentDir },
     );
     const ctx = createContext(harness.notifications);
@@ -286,11 +293,13 @@ describe("Signal Grep extension registration", () => {
   test("refuses to enable metrics through the command when a conflict package is installed", async () => {
     const agentDir = await createAgentDir(true);
     const configPath = join(agentDir, "signal-grep.json");
-    await writeSignalGrepConfig({ overrideBuiltinGrep: false }, agentDir);
+    await writeSignalGrepConfig(testConfig({ overrideBuiltinGrep: false }), agentDir);
     const configBefore = await readFile(configPath, "utf8");
     const harness = createMockPi();
 
-    await registerSignalGrepExtension(harness.pi, { overrideBuiltinGrep: false }, { agentDir });
+    await registerSignalGrepExtension(harness.pi, testConfig({ overrideBuiltinGrep: false }), {
+      agentDir,
+    });
     const metricsCommand = harness.commands.get("signal-grep-metrics");
     expect(metricsCommand).toBeDefined();
     const ctx = createContext(harness.notifications);
@@ -307,7 +316,11 @@ describe("Signal Grep extension registration", () => {
     let reloaded = false;
     const harness = createMockPi();
 
-    await registerSignalGrepExtension(harness.pi, { overrideBuiltinGrep: false }, { agentDir });
+    await registerSignalGrepExtension(
+      harness.pi,
+      testConfig({ overrideBuiltinGrep: false, locale: "zh-CN" }),
+      { agentDir },
+    );
     const metricsCommand = harness.commands.get("signal-grep-metrics");
     const ctx = createContext(harness.notifications, async () => {
       reloaded = true;
@@ -317,17 +330,20 @@ describe("Signal Grep extension registration", () => {
     const config = await readSignalGrepConfig(agentDir);
     expect(config.overrideBuiltinGrep).toBe(true);
     expect(config.startMetricsOnNextLoad).toBe(true);
+    expect(config.locale).toBe("zh-CN");
     expect(reloaded).toBe(true);
   }, 10_000);
 
   test("refuses to enable the override through the command when a conflict package is installed", async () => {
     const agentDir = await createAgentDir(true);
     const configPath = join(agentDir, "signal-grep.json");
-    await writeSignalGrepConfig({ overrideBuiltinGrep: false }, agentDir);
+    await writeSignalGrepConfig(testConfig({ overrideBuiltinGrep: false }), agentDir);
     const configBefore = await readFile(configPath, "utf8");
     const harness = createMockPi();
 
-    await registerSignalGrepExtension(harness.pi, { overrideBuiltinGrep: false }, { agentDir });
+    await registerSignalGrepExtension(harness.pi, testConfig({ overrideBuiltinGrep: false }), {
+      agentDir,
+    });
     const overrideCommand = harness.commands.get("signal-grep-override");
     expect(overrideCommand).toBeDefined();
     const ctx = createContext(harness.notifications);
@@ -339,5 +355,23 @@ describe("Signal Grep extension registration", () => {
       ),
     ).toBe(true);
     expect(await readFile(configPath, "utf8")).toBe(configBefore);
+  }, 10_000);
+  test("localizes command notifications in Simplified Chinese", async () => {
+    const agentDir = await createAgentDir(false);
+    const harness = createMockPi();
+    await registerSignalGrepExtension(harness.pi, testConfig({ locale: "zh-CN" }), { agentDir });
+    const ctx = createContext(harness.notifications);
+
+    await harness.commands.get("signal-grep-clear")?.("", ctx);
+    await harness.commands.get("signal-grep-override")?.("status", ctx);
+    await harness.commands.get("signal-grep-metrics")?.("status", ctx);
+    await harness.commands.get("signal-grep-health")?.("", ctx);
+
+    expect(harness.notifications.map((entry) => entry.message)).toEqual([
+      "Signal Grep 快照已清空",
+      "Signal Grep 覆盖已停用。",
+      "Signal Grep Metrics 已停用。如有需要，请使用 /signal-grep-metrics on 启用 grep 覆盖并开始新的对比区间。",
+      expect.stringContaining("工具模式（实际）：附加 signal_grep"),
+    ]);
   }, 10_000);
 });

--- a/test/messages.test.ts
+++ b/test/messages.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { message } from "../src/messages.js";
+
+describe("localized messages", () => {
+  test("keeps English as the exact default contract", () => {
+    expect(message("en", "healthOverrideMode")).toBe("override built-in grep");
+    expect(message("en", "overrideEnableRefused", { source: "npm:owner" })).toBe(
+      'Cannot enable Signal Grep override: "npm:owner" is installed and owns the public "grep" tool name. Remove it first, or keep using additive "signal_grep".',
+    );
+  });
+
+  test("formats Simplified Chinese command text and dynamic values", () => {
+    expect(message("zh-CN", "commandHealthDescription")).toBe(
+      "显示 ripgrep、结构提供器可用性和内存快照用量",
+    );
+    expect(message("zh-CN", "healthDegradedMode", { source: "npm:owner" })).toBe(
+      "已降级为附加 signal_grep（冲突：npm:owner）",
+    );
+  });
+
+  test("fails clearly when a required dynamic value is missing", () => {
+    expect(() => message("zh-CN", "healthDegradedMode")).toThrow(
+      "Missing Signal Grep message parameter: source",
+    );
+  });
+});

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -54,6 +54,20 @@ describe("SearchMetrics", () => {
     expect(metrics.formatReport()).toContain("used an additional 100 (100.0%)");
   });
 
+  test("formats status and reports in Simplified Chinese without changing metric values", () => {
+    const metrics = new SearchMetrics();
+    metrics.enable();
+    metrics.recordComparison("x".repeat(400), "x".repeat(1_200));
+    metrics.recordCursorPage("x".repeat(200));
+
+    expect(metrics.formatStatus(undefined, "zh-CN")).toBe(
+      "[ SG 150 ]  [ 常规 300 ]  [ ↓ 150 · 50.0% ]",
+    );
+    expect(metrics.formatReport("zh-CN")).toBe(
+      "Signal Grep Metrics：SG 150 个估算 Token（600 B）/ 常规 300（1.2 KiB）· 1 次搜索和 1 个 cursor 页面共节省 150（50.0%）。",
+    );
+  });
+
   test("uses the same conservative characters-over-four estimate as Pi", () => {
     expect(estimateTextTokens("")).toBe(0);
     expect(estimateTextTokens("12345")).toBe(2);


### PR DESCRIPTION
## Summary

Signal Grep now supports persisted English and Simplified Chinese human-facing controls while keeping model-facing search evidence and structured details unchanged.

## Motivation

Users can operate Pi in Chinese, but Signal Grep's command descriptions, notices, health output, and Metrics status were fixed to English. Localization must not alter search semantics, token accounting, or overwrite unrelated config fields.

## Public contract

- `signal-grep.json` gains `"locale": "en" | "zh-CN"`; the default is `en`.
- Existing config files without `locale` continue to use English.
- Unsupported locales fail validation explicitly.
- Human-facing command descriptions, notifications, health output, and Metrics status/reports are localized.
- Tool response text, prompt guidelines, tool parameters, cursor details, and `details` protocol constants remain English or language-neutral.
- Override and Metrics handoff commands preserve the complete validated config object.

## Design and ownership

- `messages.ts` is the typed catalog and validates translated placeholder parity during formatting.
- `extension-controls.ts` owns human-facing commands, lifecycle notices, and the single conflict-check transition policy.
- `config.ts` owns locale validation/defaulting and requires complete config writes, preventing field loss.
- `index.ts` is reduced to tool registration and runtime composition; locale never enters search formatting.

## Validation

- [x] `bun install --frozen-lockfile`
- [x] `bun run check`
- [x] `bun run pack:check`
- [ ] Real ripgrep integration behavior was tested when search semantics changed

```text
101 tests passed; format, type-aware lint, typecheck, Node smoke, benchmark,
and pack dry-run all passed. LSP reported no diagnostics.
```

## Negative paths and invariants

- [ ] No retained match can be silently omitted or duplicated
- [ ] Partial, truncated, expired, cancelled, and failed states remain observable
- [ ] Process and snapshot lifecycle cleanup is covered
- [ ] `.git`, hidden-file, ignore, regex/literal, case, and glob behavior remains intentional
- [x] Not applicable; explain why below

Search behavior is unchanged. Tests cover legacy missing-locale config, unsupported locale rejection, English contract text, Chinese dynamic interpolation, missing message parameters, Chinese command surfaces, localized Metrics values, and locale preservation across Metrics handoff writes.

## Risk and rollback

The main compatibility risk is config validation, mitigated by defaulting legacy files to English and rejecting only unsupported explicit values. Rollback is a clean revert; existing files containing `locale` would be ignored by the previous parser without changing tool mode.

## Documentation

- [x] English README or docs updated
- [x] Simplified Chinese README updated when user-facing behavior changed
- [x] Changelog updated
- [ ] No documentation change required

## AI provenance

- **AI agent/model family:** GPT-5.6 Sol via Pi; independent reviewer subagent used for final stack review
- **Human final-diff review:** No; maintainer authorized remote submission after AI review
- **Validation executed by AI:** frozen install, LSP, `bun run check`, `bun run pack:check`, final diff review
- **Unverified claims or remaining uncertainty:** None material; CI is pending

## Final review

- [x] The branch is focused and contains no unrelated changes
- [x] The final diff was reviewed
- [x] No generated artifacts, credentials, private source, or logs are committed
- [x] This PR does not publish, release, or merge itself
