### PR TITLE
chore: release 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes will be documented in this file. The project follows [Semant
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-09-03
+
 ### Changed
 
-- Explicit absolute paths and `..` traversal can now search and inspect outside the current working directory. The default remains cwd-scoped, ordinary Git change comparison remains cwd-scoped, and `.git` internals plus known external credential and special-system areas are rejected with canonical-path checks.
+- Explicit absolute paths and `..` traversal can search and inspect outside the current working directory. Requests without a path remain cwd-scoped, Git change comparison remains cwd-scoped, and canonical path checks reject `.git` internals and known external credential and special-system areas.
 
 ## [0.6.0] - 2026-09-02
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-plugin-signal-grep",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "Context-efficient, correctness-first ripgrep search and bounded code inspection for the Pi coding agent",
   "keywords": [
     "ai-agent",

--- a/test/syntax-install.test.ts
+++ b/test/syntax-install.test.ts
@@ -96,7 +96,7 @@ const fixtures = [
 
 describe("production parser assets", () => {
   test("Node runs all four grammars with only the actual installed production packages", async () => {
-    expect(await readdir(join(isolated, "node_modules"))).toEqual([
+    expect((await readdir(join(isolated, "node_modules"))).toSorted()).toEqual([
       "@ast-grep",
       "pi-plugin-signal-grep",
     ]);


### PR DESCRIPTION
## Summary

- set the package version to 0.6.2
- move the external-path change into the 0.6.2 changelog entry
- leave README and other documentation unchanged

## Validation

- `bun run check`
- `bun run pack:check`
