### PR TITLE
chore: use npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run check
       - run: bun run pack:check
+      - name: Install npm with trusted publishing support
+        run: npm install --global npm@11.15.0
       - name: Publish with npm provenance
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Switch npm publishing authentication from the repository secret to the configured npm Trusted Publisher.

## Motivation

The package now has an OIDC trust for this GitHub Actions workflow. npm requires CLI 11.5.1 or newer for trusted publishing.

## Public contract

No public contract change.

## Design and ownership

The release workflow owns publication authentication. It installs a pinned compatible npm CLI and no longer injects a long-lived publish token.

## Validation

- [x] `bun install --frozen-lockfile`
- [x] `bun run check`
- [x] `bun run pack:check`
- [x] Real ripgrep integration behavior was tested when search semantics changed

```text
295 pass, 0 fail, 2057 assertions; pack check: 79 files, 0.97 MB.
```

## Negative paths and invariants

- [x] Not applicable; publish authentication only. Search behavior is unchanged.

## Risk and rollback

Risk is limited to the next publish authentication path. npm Trusted Publisher is configured for `xcjy8bao/baoer_signal_grep` and `.github/workflows/publish.yml`; revert this commit and restore a package-scoped token only if OIDC fails.

## Documentation

- [x] No documentation change required

## AI provenance

- **AI agent/model family:** OpenAI Codex
- **Human final-diff review:** Yes
- **Validation executed by AI:** `bun run check`; `bun run pack:check`; `git diff --check`
- **Unverified claims or remaining uncertainty:** OIDC will be exercised by the next version publish because npm versions are immutable.

## Final review

- [x] The branch is focused and contains no unrelated changes
- [x] The final diff was reviewed
- [x] No generated artifacts, credentials, private source, or logs are committed
- [x] This PR does not publish, release, or merge itself