### PR TITLE
ci: publish npm from GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,8 @@
 name: Publish npm release
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Reviewed release tag at the current main commit (for example v0.5.6)"
-        required: true
-        type: string
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -17,7 +13,6 @@ concurrency:
 
 jobs:
   publish:
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -30,7 +25,7 @@ jobs:
           persist-credentials: false
       - name: Verify reviewed tag and package identity
         env:
-          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           node --input-type=module <<'NODE'
           import { execFileSync } from 'node:child_process';

--- a/docs/QUALITY_GATES.md
+++ b/docs/QUALITY_GATES.md
@@ -143,4 +143,4 @@ Required checks and pull-request rules are configured on `main` and apply to adm
 
 ## Publication boundary
 
-The manual publication workflow validates a release tag against the current `main` commit and package metadata, reruns the quality/package gates, and publishes with npm provenance from GitHub Actions. Publication remains a separately authorized action; local validation is not permission to publish.
+Publishing a GitHub Release automatically runs the npm publication workflow. The workflow validates the release tag against the current `main` commit and package metadata, reruns the quality/package gates, and publishes through the package's OIDC Trusted Publisher with npm provenance. Publishing the GitHub Release is the explicit publication boundary; local validation alone is not permission to publish.


### PR DESCRIPTION
## Summary

Automatically publish the matching npm package whenever a GitHub Release is published.

## Motivation

Release creation should be the single explicit publication action. The npm job now runs from the `release.published` event through the configured OIDC Trusted Publisher.

## Public contract

No runtime or package API change. Publishing a GitHub Release now triggers npm publication automatically.

## Design and ownership

The existing release workflow remains the single owner. It reads the release tag from the event and preserves the checks that require that tag, `HEAD`, and `origin/main` to identify the same reviewed commit.

## Validation

- [x] `bun install --frozen-lockfile`
- [x] `bun run check`
- [x] `bun run pack:check`
- [x] Real ripgrep integration behavior was tested when search semantics changed

```text
295 pass, 0 fail, 2057 assertions; pack check: 79 files, 0.97 MB.
```

## Negative paths and invariants

- [x] Not applicable; the existing version, package identity, and main/tag checks remain fail-closed.

## Risk and rollback

A malformed or stale release tag fails before publication. Revert this commit to restore manual dispatch.

## Documentation

- [x] English quality-gate documentation updated
- [x] Simplified Chinese README updated when user-facing behavior changed (not applicable)
- [x] Changelog updated (not applicable)

## AI provenance

- **AI agent/model family:** OpenAI Codex
- **Human final-diff review:** Yes
- **Validation executed by AI:** `bun run check`; `bun run pack:check`; `git diff --check`
- **Unverified claims or remaining uncertainty:** The event-triggered OIDC path will first execute on the next immutable package version.

## Final review

- [x] The branch is focused and contains no unrelated changes
- [x] The final diff was reviewed
- [x] No generated artifacts, credentials, private source, or logs are committed
- [x] This PR does not publish, release, or merge itself