### PR TITLE
fix: follow latest release for every MCP connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Make every MCP installation command follow the latest published version when the server starts.
+
 ## [1.2.0] - 2026-09-05
 
 - Fix missing file maps and matching lines in MCP clients that select structured results.

--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ Restart Pi after installing or updating. Pi uses this plugin for conventional se
 ### Claude Code or Codex: MCP connection
 
 ```bash
-claude mcp add baoer_signal_grep -- npx -y --package baoer_signal_grep baoer_signal_grep_mcp --stdio
+claude mcp add baoer_signal_grep -- npx -y --package baoer_signal_grep@latest baoer_signal_grep_mcp --stdio
 ```
 
 ```bash
-codex mcp add baoer_signal_grep -- npx -y --package baoer_signal_grep baoer_signal_grep_mcp --stdio
+codex mcp add baoer_signal_grep -- npx -y --package baoer_signal_grep@latest baoer_signal_grep_mcp --stdio
 ```
 
-Restart the host after setup or updates. The server searches the active project; `BAOER_SIGNAL_GREP_MCP_CWD` can select a different root. An MCP-only connection adds the tool without disabling other search tools.
+`@latest` follows the newest published version when MCP starts. Restart the host to load updates. The server searches the active project; `BAOER_SIGNAL_GREP_MCP_CWD` can select a different root. An MCP-only connection adds the tool without disabling other search tools.
 
 ### Native plugins
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -62,14 +62,14 @@ pi install npm:baoer_signal_grep
 ### Claude Code 或 Codex：连接 MCP
 
 ```bash
-claude mcp add baoer_signal_grep -- npx -y --package baoer_signal_grep baoer_signal_grep_mcp --stdio
+claude mcp add baoer_signal_grep -- npx -y --package baoer_signal_grep@latest baoer_signal_grep_mcp --stdio
 ```
 
 ```bash
-codex mcp add baoer_signal_grep -- npx -y --package baoer_signal_grep baoer_signal_grep_mcp --stdio
+codex mcp add baoer_signal_grep -- npx -y --package baoer_signal_grep@latest baoer_signal_grep_mcp --stdio
 ```
 
-配置或更新后重启宿主。服务器默认搜索当前项目，可用 `BAOER_SIGNAL_GREP_MCP_CWD` 指定其他根目录。仅连接 MCP 会添加工具，不会禁用其他搜索工具。
+`@latest` 会在 MCP 启动时跟随最新发布版本，更新后重启宿主即可加载。服务器默认搜索当前项目，可用 `BAOER_SIGNAL_GREP_MCP_CWD` 指定其他根目录。仅连接 MCP 会添加工具，不会禁用其他搜索工具。
 
 ### 原生插件
 

--- a/plugins/baoer-signal-grep/.mcp.json
+++ b/plugins/baoer-signal-grep/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--yes",
         "--package",
-        "baoer_signal_grep@1.2.0",
+        "baoer_signal_grep@latest",
         "baoer_signal_grep_mcp",
         "--stdio"
       ],

--- a/plugins/baoer-signal-grep/kimi.plugin.json
+++ b/plugins/baoer-signal-grep/kimi.plugin.json
@@ -13,7 +13,7 @@
       "args": [
         "--yes",
         "--package",
-        "baoer_signal_grep@1.2.0",
+        "baoer_signal_grep@latest",
         "baoer_signal_grep_mcp",
         "--stdio"
       ],

--- a/scripts/search-policy-artifact.ts
+++ b/scripts/search-policy-artifact.ts
@@ -60,7 +60,7 @@ export async function buildSearchPlugin(root: string): Promise<void> {
       args: [
         "--yes",
         "--package",
-        `${packageJson.name}@${packageJson.version}`,
+        `${packageJson.name}@latest`,
         "baoer_signal_grep_mcp",
         "--stdio",
       ],


### PR DESCRIPTION
## Change

MCP startup now requests `baoer_signal_grep@latest` for Claude Code, Codex and Kimi instead of a fixed release. The generated native manifests and documented setup commands agree, so restarting an MCP server follows the newest published package.

## Validation

- [x] `bun run check:local`: 327 passed, 1 optional model test skipped
- [x] `bun run pack:check`
- [x] Reviewed the final diff and shipped artifacts

Validated an actual published 1.2.0 installation through Node stdio, Claude Code and Codex CLI, including complete result bodies and pagination. Private regression checks reject the previous fixed-version manifests and pass for the regenerated files.

## Compatibility and risks

The plugin manifest retains its actual release identity. Following `latest` takes effect when the MCP process starts; it does not replace a running process. The already-published npm 1.2.0 archive is immutable and keeps its original embedded manifests until a subsequent release.

## Documentation

- [x] Updated English and Chinese installation instructions
- [x] No private source, tests, internal documents, credentials or logs are included

## AI assistance

Implemented and verified with Codex (GPT-6 family). No human final-diff review claimed.
