### PR TITLE
fix: resolve open search issues

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
           import { execFileSync } from 'node:child_process';
           import { readFileSync } from 'node:fs';
           const tag = process.env.RELEASE_TAG;
-          if (!/^v\d+\.\d+\.\d+$/.test(tag ?? '')) throw new Error('Invalid release tag');
+          if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(tag ?? '')) throw new Error('Invalid release tag');
           const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim();
           const commit = git('rev-parse', `${tag}^{commit}`);
           if (commit !== git('rev-parse', 'origin/main') || commit !== git('rev-parse', 'HEAD')) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.3-1] - 2026-09-06
+
+- Scope semantic project snapshots and stability checks to the target's containing project boundary, so unrelated files outside that project do not invalidate navigation.
+- Make file-discovery validation errors name the valid discovery modes and show the `mode="files"` plus `query` repair shape.
+- Rank file-discovery candidates relative to the requested root, so the root's own path cannot create false filename matches.
+
 ## [1.2.3] - 2026-09-06
 
 - Add native OMP (Oh My Pi) compatibility with the `baoer_signal_grep` tool, profile-aware configuration, direct-search enforcement, lifecycle cleanup and a self-contained published extension bundle.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer_signal_grep",
-  "version": "1.2.3",
+  "version": "1.2.3-1",
   "description": "Context-efficient local search for files, documents, notes and logs across Pi, OMP and MCP clients",
   "keywords": [
     "ai-agent",

--- a/plugins/baoer-signal-grep/.claude-plugin/plugin.json
+++ b/plugins/baoer-signal-grep/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer-signal-grep",
-  "version": "1.2.3",
+  "version": "1.2.3-1",
   "description": "Require baoer_signal_grep for conventional local searches while keeping development tools available.",
   "author": {
     "name": "宝儿"

--- a/plugins/baoer-signal-grep/.codex-plugin/plugin.json
+++ b/plugins/baoer-signal-grep/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer-signal-grep",
-  "version": "1.2.3",
+  "version": "1.2.3-1",
   "description": "Require baoer_signal_grep for conventional local searches while keeping development tools available.",
   "author": {
     "name": "宝儿"

--- a/plugins/baoer-signal-grep/kimi.plugin.json
+++ b/plugins/baoer-signal-grep/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer-signal-grep",
-  "version": "1.2.3",
+  "version": "1.2.3-1",
   "description": "Require baoer_signal_grep for conventional local searches while keeping development tools available.",
   "author": {
     "name": "宝儿"

--- a/plugins/baoer-signal-grep/omp-extension.mjs
+++ b/plugins/baoer-signal-grep/omp-extension.mjs
@@ -1677,7 +1677,7 @@ function executablePath() {
     throw new SignalGrepError(`TypeScript semantic provider is unavailable for ${process.platform}/${process.arch}; reinstall with optional dependencies enabled`, { cause: error });
   }
 }
-async function runTypeScript(cwd, documents, operation, parent) {
+async function runTypeScript(cwd, documents, operation, parent, sourceCwd = cwd) {
   const executable = executablePath();
   const deadline = new AbortController;
   const signal = parent ? AbortSignal.any([parent, deadline.signal]) : deadline.signal;
@@ -1714,7 +1714,7 @@ async function runTypeScript(cwd, documents, operation, parent) {
         settings: { "js/ts": preferences, typescript: preferences, javascript: preferences }
       });
       for (const document2 of documents) {
-        const uri = await semanticUri(cwd, document2.path);
+        const uri = await semanticUri(sourceCwd, document2.path);
         await channel.notify("textDocument/didOpen", {
           textDocument: {
             uri,
@@ -1739,8 +1739,8 @@ async function runTypeScript(cwd, documents, operation, parent) {
     clearTimeout(timer);
   }
 }
-function withTypeScript(cwd, documents, operation, parent) {
-  return compilerQueue.run(() => runTypeScript(cwd, documents, operation, parent), parent);
+function withTypeScript(cwd, documents, operation, parent, sourceCwd = cwd) {
+  return compilerQueue.run(() => runTypeScript(cwd, documents, operation, parent, sourceCwd), parent);
 }
 
 // src/syntax.ts
@@ -2425,6 +2425,16 @@ async function bindImpactCandidates(target, files, occurrences, access2) {
   }
   return { items: [...retained.values()], bound };
 }
+
+// src/discovery-errors.ts
+var FILE_DISCOVERY_QUERY_PLACEHOLDER = "<filename-or-path>";
+function repairQuery(value) {
+  return typeof value === "string" && value.length <= 256 && value.isWellFormed() && !/[\r\n\0]/.test(value) ? value : FILE_DISCOVERY_QUERY_PLACEHOLDER;
+}
+function fileDiscoveryQueryHint(value) {
+  return `file discovery uses query; retry with ${JSON.stringify({ mode: "files", query: repairQuery(value) })}`;
+}
+var DISCOVERY_MODE_REQUIRED_ERROR = 'query requires an explicit discovery mode: use mode=files for filename/path discovery or mode=concept for semantic discovery; for example {"mode":"files","query":"<filename-or-path>"}';
 
 // src/concept-search.ts
 import { dirname as dirname4 } from "path";
@@ -4202,20 +4212,87 @@ function rankEvidence(items, priority) {
 }
 
 // src/semantic-navigation.ts
-import { resolve as resolve13 } from "path";
+import { resolve as resolve14 } from "path";
 
 // src/semantic-project.ts
-import { resolve as resolve12 } from "path";
+import { resolve as resolve13 } from "path";
+
+// src/project-root.ts
+import { readdir, realpath as realpath5 } from "fs/promises";
+import { dirname as dirname5, relative as relative7, resolve as resolve12 } from "path";
+var TYPESCRIPT_CONFIG_FILE = /^[tj]sconfig[^/]*\.json$/i;
+function isMissingPath(error) {
+  return error instanceof Error && "code" in error && (error.code === "ENOENT" || error.code === "ENOTDIR");
+}
+async function projectConfig(directory, signal) {
+  if (signal?.aborted)
+    throw abortError();
+  try {
+    const entries = await readdir(directory, { withFileTypes: true });
+    const files = entries.filter((entry) => entry.isFile() || entry.isSymbolicLink());
+    if (files.some((entry) => TYPESCRIPT_CONFIG_FILE.test(entry.name)))
+      return "typescript";
+    if (files.some((entry) => entry.name.toLowerCase() === "package.json"))
+      return "package";
+    return;
+  } catch (error) {
+    if (isMissingPath(error))
+      return;
+    throw error;
+  }
+}
+async function gitRootWithinCwd(cwd, gitRoot) {
+  const absoluteCwd = resolve12(cwd);
+  const [canonicalCwd, canonicalRoot] = await Promise.all([
+    realpath5(absoluteCwd),
+    realpath5(gitRoot)
+  ]);
+  if (!isPathInsideCwd(canonicalRoot, canonicalCwd))
+    return;
+  return resolve12(absoluteCwd, relative7(canonicalCwd, canonicalRoot));
+}
+async function resolveSemanticProjectRoot(cwd, targetPath, signal) {
+  const absoluteCwd = resolve12(cwd);
+  const absoluteTarget = resolve12(absoluteCwd, targetPath);
+  if (!isPathInsideCwd(absoluteTarget, absoluteCwd))
+    return absoluteCwd;
+  const targetDirectory = dirname5(absoluteTarget);
+  const gitRoot = await findGitRepository(targetDirectory, signal);
+  if (gitRoot) {
+    const localGitRoot = await gitRootWithinCwd(absoluteCwd, gitRoot);
+    if (localGitRoot)
+      return localGitRoot;
+  }
+  let packageRoot;
+  let current = targetDirectory;
+  while (isPathInsideCwd(current, absoluteCwd)) {
+    const marker = await projectConfig(current, signal);
+    if (marker === "typescript")
+      return current;
+    if (marker === "package" && packageRoot === undefined)
+      packageRoot = current;
+    if (current === absoluteCwd)
+      break;
+    const parent = dirname5(current);
+    if (parent === current || !isPathInsideCwd(parent, absoluteCwd))
+      break;
+    current = parent;
+  }
+  return packageRoot ?? targetDirectory;
+}
+
+// src/semantic-project.ts
 async function semanticProject(access2, targetPath) {
-  const files = await listWorkspaceFiles(access2.cwd, access2.signal);
+  const root = await resolveSemanticProjectRoot(access2.cwd, targetPath, access2.signal);
+  const files = await listWorkspaceFiles(access2.cwd, access2.signal, { path: root });
   const paths = files.paths.filter((path) => {
     const language = syntaxLanguage(path);
     return language && language !== "go";
   });
-  const target = resolve12(access2.cwd, targetPath);
-  if (!paths.some((path) => resolve12(access2.cwd, path) === target))
+  const target = resolve13(access2.cwd, targetPath);
+  if (!paths.some((path) => resolve13(access2.cwd, path) === target))
     throw new SignalGrepError("Semantic target must be an admitted JS/TS workspace file under current ignore rules");
-  paths.sort((a, b) => Number(resolve12(access2.cwd, b) === target) - Number(resolve12(access2.cwd, a) === target) || a.localeCompare(b));
+  paths.sort((a, b) => Number(resolve13(access2.cwd, b) === target) - Number(resolve13(access2.cwd, a) === target) || a.localeCompare(b));
   const documents = new Map;
   const reasons = [...files.reasons];
   const metadata2 = [];
@@ -4228,7 +4305,7 @@ async function semanticProject(access2, targetPath) {
       if (!document2.utf8)
         throw new SourceDocumentError("encoding", `Non-UTF-8 semantic source: ${path}`);
       if (paths.includes(path))
-        documents.set(resolve12(access2.cwd, path), document2);
+        documents.set(resolve13(access2.cwd, path), document2);
       else
         metadata2.push(document2);
     } catch (error) {
@@ -4250,7 +4327,7 @@ async function semanticProject(access2, targetPath) {
         throw new Error("Expected worktree semantic source");
       await access2.refresh(document2.path, document2.reference);
     }
-    const after = await listWorkspaceFiles(access2.cwd, access2.signal);
+    const after = await listWorkspaceFiles(access2.cwd, access2.signal, { path: root });
     if (JSON.stringify(after) !== JSON.stringify(files))
       throw new SignalGrepError("Workspace file set changed during semantic query; retry");
   };
@@ -4268,7 +4345,7 @@ async function semanticProject(access2, targetPath) {
     },
     stats: { filesEnumerated: paths.length, filesSkipped: paths.length - documents.size }
   };
-  return { documents, primary, result, recheck };
+  return { documents, primary, result, recheck, root };
 }
 
 // src/semantic-navigation.ts
@@ -4359,7 +4436,7 @@ async function runSemanticNavigation(input, access2) {
   if (!input.path || !isSemanticMode(input.mode))
     throw new SignalGrepError("Semantic navigation requires a mode and workspace path");
   const project = await semanticProject(access2, input.path);
-  const { result, documents, primary } = project;
+  const { result, documents, primary, root } = project;
   result.kind = input.mode;
   result.redact = input.redact ?? false;
   const mode = input.mode;
@@ -4377,7 +4454,7 @@ async function runSemanticNavigation(input, access2) {
       result.reasons.push("Compiler returned a location outside admitted source coverage; dependency/ignored/over-budget source was not exposed");
     }
   };
-  await withTypeScript(access2.cwd, [...documents.values()], async (channel) => {
+  await withTypeScript(root, [...documents.values()], async (channel) => {
     if (!graph) {
       const found = await queryLocations(channel, mode, {
         textDocument: { uri: await semanticUri(access2.cwd, primary.path) },
@@ -4422,7 +4499,7 @@ async function runSemanticNavigation(input, access2) {
             await add(target, "dependency");
           } else if (targetDocument === primary) {
             await add({
-              path: resolve13(access2.cwd, document2.path),
+              path: resolve14(access2.cwd, document2.path),
               range: {
                 start: lspPosition(document2, specifier.start),
                 end: lspPosition(document2, specifier.end)
@@ -4433,7 +4510,7 @@ async function runSemanticNavigation(input, access2) {
       }
       access2.releaseSyntax(document2);
     }
-  }, access2.signal);
+  }, access2.signal, access2.cwd);
   await project.recheck();
   result.filesRead = access2.filesRead;
   result.bytesRead = access2.bytesRead;
@@ -4455,7 +4532,7 @@ function navigateSemantics(input, access2) {
 }
 
 // src/evidence-service.ts
-import { dirname as dirname5, resolve as resolve18 } from "path";
+import { dirname as dirname6, resolve as resolve20 } from "path";
 
 // src/analysis-store.ts
 import { randomUUID } from "crypto";
@@ -4784,7 +4861,7 @@ Inspect: ${JSON.stringify(inspect)}` : ""}`;
 }
 
 // src/inspect.ts
-import { resolve as resolve14 } from "path";
+import { resolve as resolve15 } from "path";
 function resolveInspectionTarget(input, cwd, snapshots) {
   let path = input.path?.replace(/^@/, "");
   let line = input.line;
@@ -4811,7 +4888,7 @@ function resolveInspectionTarget(input, cwd, snapshots) {
   if (line === undefined || !Number.isSafeInteger(line) || line < 1) {
     throw new SignalGrepError("line must be a positive integer when mode=inspect");
   }
-  const absolutePath = retainedMatch?.absolutePath ?? resolve14(cwd, path);
+  const absolutePath = retainedMatch?.absolutePath ?? resolve15(cwd, path);
   new SearchPathPolicy(cwd).assertPath(absolutePath);
   let expectedRevision;
   if (input.cursor) {
@@ -4833,7 +4910,7 @@ function resolveInspectionTarget(input, cwd, snapshots) {
 }
 
 // src/evidence-candidates.ts
-import { resolve as resolve15 } from "path";
+import { resolve as resolve16 } from "path";
 class CandidateLimit extends SignalGrepError {
 }
 function record(value) {
@@ -4995,7 +5072,7 @@ async function ordinaryCandidates(options) {
 async function collectEvidenceCandidates(options) {
   if (!options.changes)
     return ordinaryCandidates(options);
-  if (options.request.path && !isPathInsideCwd(resolve15(options.cwd, options.request.path), options.cwd)) {
+  if (options.request.path && !isPathInsideCwd(resolve16(options.cwd, options.request.path), options.cwd)) {
     throw new SignalGrepError("Git changes for paths outside cwd are not supported; relaunch Pi from that repository or a common parent");
   }
   const reasons = new Set;
@@ -6749,10 +6826,10 @@ async function runOwnedParallel(start2, parent) {
 }
 
 // src/file-discovery.ts
-import { posix as posix4 } from "path";
+import { basename as platformBasename, posix as posix4, relative as relative8, resolve as resolve18, sep as sep4 } from "path";
 
 // src/file-metadata-filter.ts
-import { resolve as resolve16 } from "path";
+import { resolve as resolve17 } from "path";
 async function filterPathsByModificationTime(cwd, paths, modifiedAfterMs, modifiedBeforeMs, signal) {
   if (modifiedAfterMs === undefined && modifiedBeforeMs === undefined)
     return { paths: [...paths], partial: false, reasons: [] };
@@ -6763,7 +6840,7 @@ async function filterPathsByModificationTime(cwd, paths, modifiedAfterMs, modifi
       throw abortError();
     const batch = paths.slice(offset, offset + MAX_SOURCE_REVISION_CONCURRENCY);
     const revisions = await Promise.all(batch.map(async (path) => {
-      const revision = await getSourceRevision(resolve16(cwd, path));
+      const revision = await getSourceRevision(resolve17(cwd, path));
       return revision ? { path, revision } : { path };
     }));
     for (const { path, revision } of revisions) {
@@ -6819,23 +6896,31 @@ function scoreFilePath(path, query) {
     reason: "ordered fuzzy path characters; candidate, not an exact filename"
   };
 }
+function pathRelativeToDiscoveryRoot(cwd, root, path) {
+  const absoluteRoot = resolve18(cwd, root);
+  const absolutePath = resolve18(cwd, path);
+  const scoped = relative8(absoluteRoot, absolutePath).split(sep4).join("/");
+  return scoped || platformBasename(absolutePath);
+}
 async function discoverFiles(input, cwd, signal) {
   const query = input.query ?? "";
   if (query.length > 256 || !query.isWellFormed() || /[\r\n\0]/.test(query))
     throw new SignalGrepError("File query must be well-formed single-line text of at most 256 characters");
   const request = normalizeRequest({ ...input, pattern: "" });
+  const policy = new SearchPathPolicy(cwd);
+  const discoveryRoot = request.path ?? ".";
+  const scoringRoot = await policy.resolveSearchTarget(discoveryRoot);
   const files = await listWorkspaceFiles(cwd, signal, {
-    ...request.path ? { path: request.path } : {},
+    path: scoringRoot,
     glob: request.glob,
     exclude: request.exclude,
     hidden: request.hidden
   });
   const filtered = await filterPathsByModificationTime(cwd, files.paths, request.modifiedAfterMs, request.modifiedBeforeMs, signal);
   const selected = filtered.paths.flatMap((path) => {
-    const rank = scoreFilePath(path, query);
+    const rank = scoreFilePath(pathRelativeToDiscoveryRoot(cwd, scoringRoot, path), query);
     return rank ? [{ path, ...rank }] : [];
   }).toSorted((left, right) => right.score - left.score || left.path.localeCompare(right.path));
-  const policy = new SearchPathPolicy(cwd);
   for (let offset = 0;offset < selected.length; offset += 16) {
     await Promise.all(selected.slice(offset, offset + 16).map((item) => policy.assertExistingPath(item.path)));
     signal?.throwIfAborted();
@@ -7069,7 +7154,7 @@ class SourceContinuations {
 }
 
 // src/source-inspection.ts
-import { resolve as resolve17 } from "path";
+import { resolve as resolve19 } from "path";
 function legacySourceTarget(target) {
   return {
     path: target.path,
@@ -7135,7 +7220,7 @@ async function prepare(target, access2, structure) {
     }
   } else if (document2.utf8 && structure && document2.reference.origin.kind === "worktree" && !target.range) {
     const result = await structure.inspect({
-      absolutePath: resolve17(access2.cwd, target.path),
+      absolutePath: resolve19(access2.cwd, target.path),
       cwd: access2.cwd,
       line: target.line,
       expectedRevision: document2.reference.origin.revision
@@ -7312,7 +7397,7 @@ ${preview.text}`);
     if (block.remaining.length)
       block.continuation = continuations.create(block.document.reference, block.ranges, block.remaining);
     if (block.document.reference.origin.kind === "worktree") {
-      const current = await getSourceRevision(resolve17(access2.cwd, block.document.path));
+      const current = await getSourceRevision(resolve19(access2.cwd, block.document.path));
       if (!current || !sameSourceRevision(current, block.document.reference.origin.revision)) {
         block.text = [];
         block.fragments = [];
@@ -7887,10 +7972,10 @@ function parsePythonOutline(document2) {
 function isEvidenceRequest(input) {
   return isSemanticMode(input.mode) || input.mode === "concept" || input.mode === "structure" || input.mode === "files" || input.mode === "inspect" || input.mode === "outline" || input.mode === "imports" || input.mode === "tests" || input.mode === "impact" || input.sourceCursor !== undefined || input.anyOf !== undefined || input.allOf !== undefined || input.within !== undefined || input.roles !== undefined || input.changes !== undefined || input.symbol !== undefined || (input.cursor?.includes(".analysis") ?? false);
 }
-function rejectFields(input, fields, operation, cursor = false) {
+function rejectFields(input, fields, operation, cursor = false, hint = "copy the complete returned request") {
   const present = fields.filter((field) => input[field] !== undefined);
   if (present.length)
-    throw cursor ? new CursorError(`${operation} does not accept ${present.join(", ")}; copy the complete returned request`, "E_CURSOR_OPTIONS_CONFLICT") : new SignalGrepError(`${operation} does not accept ${present.join(", ")}; copy the complete returned request`);
+    throw cursor ? new CursorError(`${operation} does not accept ${present.join(", ")}; ${hint}`, "E_CURSOR_OPTIONS_CONFLICT") : new SignalGrepError(`${operation} does not accept ${present.join(", ")}; ${hint}`);
 }
 var searchFields = [
   "query",
@@ -7988,10 +8073,10 @@ function searchScope(request) {
   };
 }
 async function navigationRoot(cwd, path, signal) {
-  const absolute = resolve18(cwd, path);
+  const absolute = resolve20(cwd, path);
   if (isPathInsideCwd(absolute, cwd))
-    return resolve18(cwd);
-  return await findGitRepository(dirname5(absolute), signal) ?? dirname5(absolute);
+    return resolve20(cwd);
+  return await findGitRepository(dirname6(absolute), signal) ?? dirname6(absolute);
 }
 
 class EvidenceService {
@@ -8124,7 +8209,7 @@ class EvidenceService {
         "roles",
         "changes",
         ...inspectFields
-      ], "mode=files");
+      ], "mode=files", false, fileDiscoveryQueryHint(input.query ?? input.pattern));
       return this.#analyses.page(this.#analyses.create(await discoverFiles(input, cwd, signal)));
     }
     if (input.mode === "impact")
@@ -8451,14 +8536,14 @@ class EvidenceService {
       reasons.add("Related-test augmentation skipped: exact occurrences exhausted the shared analysis budget");
     } else {
       const files = await listWorkspaceFiles(access2.cwd, access2.signal, { path: root });
-      const allowed = new Set(files.paths.map((file) => resolve18(access2.cwd, file)));
-      const primaryPath = resolve18(access2.cwd, document2.path);
+      const allowed = new Set(files.paths.map((file) => resolve20(access2.cwd, file)));
+      const primaryPath = resolve20(access2.cwd, document2.path);
       const host = {
         cwd: access2.cwd,
         ...access2.signal ? { signal: access2.signal } : {},
         normalizePath: (file) => workspaceRelativePath(access2.cwd, file),
         load: async (file, expected) => {
-          const absolutePath = resolve18(access2.cwd, file);
+          const absolutePath = resolve20(access2.cwd, file);
           if (!allowed.has(absolutePath))
             throw new SignalGrepError("Navigation source is excluded by current ignore rules");
           if (absolutePath === primaryPath && expected === undefined)
@@ -8625,14 +8710,14 @@ class EvidenceService {
       }));
     const root = await navigationRoot(access2.cwd, document2.path, access2.signal);
     const files = await listWorkspaceFiles(access2.cwd, access2.signal, { path: root });
-    const allowed = new Set(files.paths.map((file) => resolve18(access2.cwd, file)));
-    const primaryPath = resolve18(access2.cwd, document2.path);
+    const allowed = new Set(files.paths.map((file) => resolve20(access2.cwd, file)));
+    const primaryPath = resolve20(access2.cwd, document2.path);
     const host = {
       cwd: access2.cwd,
       ...access2.signal ? { signal: access2.signal } : {},
       normalizePath: (file) => workspaceRelativePath(access2.cwd, file),
       load: async (file, expected) => {
-        const absolutePath = resolve18(access2.cwd, file);
+        const absolutePath = resolve20(access2.cwd, file);
         if (!allowed.has(absolutePath))
           throw new SignalGrepError("Navigation source is excluded by current ignore rules");
         if (absolutePath === primaryPath && expected === undefined)
@@ -8673,7 +8758,7 @@ class EvidenceService {
 }
 
 // src/service.ts
-import { resolve as resolve19 } from "path";
+import { resolve as resolve21 } from "path";
 
 // src/format.ts
 import { readFile as readFile3 } from "fs/promises";
@@ -9266,7 +9351,7 @@ function cursorPathSelection(input, cwd) {
     validateSearchPath(label, input.paths !== undefined ? "paths" : "path");
     if (label.length === 0)
       throw new SignalGrepError("Cursor paths cannot be empty");
-    const absolutePath = resolve19(cwd, label);
+    const absolutePath = resolve21(cwd, label);
     policy.assertPath(absolutePath);
     if (absolutePaths.has(absolutePath))
       continue;
@@ -9448,7 +9533,7 @@ class SignalGrepService {
     if (input.column !== undefined)
       throw new SignalGrepError("column requires semantic navigation");
     if (input.query !== undefined)
-      throw new SignalGrepError("query requires a discovery mode");
+      throw new SignalGrepError(DISCOVERY_MODE_REQUIRED_ERROR);
     if (input.maxFilesToParse !== undefined) {
       throw new SignalGrepError("maxFilesToParse is only valid for structural analysis requests");
     }
@@ -14014,10 +14099,10 @@ class TuiBase extends Container {
     return null;
   }
   queryTerminalBackgroundColor({ timeoutMs }) {
-    return new Promise((resolve20) => {
+    return new Promise((resolve22) => {
       const query = {
         settled: false,
-        resolve: resolve20,
+        resolve: resolve22,
         timer: undefined
       };
       query.timer = setTimeout(() => {
@@ -14035,7 +14120,7 @@ class TuiBase extends Container {
     });
   }
   queryTerminalColorScheme({ timeoutMs }) {
-    return new Promise((resolve20) => {
+    return new Promise((resolve22) => {
       let settled = false;
       let timer;
       let unsubscribe = () => {};
@@ -14048,7 +14133,7 @@ class TuiBase extends Container {
           timer = undefined;
         }
         unsubscribe();
-        resolve20(scheme);
+        resolve22(scheme);
       };
       unsubscribe = this.onTerminalColorSchemeChange(settle);
       timer = setTimeout(() => settle(undefined), timeoutMs);
@@ -18743,8 +18828,8 @@ var Module2 = (() => {
     var moduleRtn;
     var Module = moduleArg;
     var readyPromiseResolve, readyPromiseReject;
-    var readyPromise = new Promise((resolve20, reject) => {
-      readyPromiseResolve = resolve20;
+    var readyPromise = new Promise((resolve22, reject) => {
+      readyPromiseResolve = resolve22;
       readyPromiseReject = reject;
     });
     var ENVIRONMENT_IS_WEB = typeof window == "object";
@@ -18824,13 +18909,13 @@ var Module2 = (() => {
         }
         readAsync = /* @__PURE__ */ __name(async (url) => {
           if (isFileURI(url)) {
-            return new Promise((resolve20, reject) => {
+            return new Promise((resolve22, reject) => {
               var xhr = new XMLHttpRequest;
               xhr.open("GET", url, true);
               xhr.responseType = "arraybuffer";
               xhr.onload = () => {
                 if (xhr.status == 200 || xhr.status == 0 && xhr.response) {
-                  resolve20(xhr.response);
+                  resolve22(xhr.response);
                   return;
                 }
                 reject(xhr.status);
@@ -19050,10 +19135,10 @@ var Module2 = (() => {
       __name(receiveInstantiationResult, "receiveInstantiationResult");
       var info2 = getWasmImports();
       if (Module["instantiateWasm"]) {
-        return new Promise((resolve20, reject) => {
+        return new Promise((resolve22, reject) => {
           Module["instantiateWasm"](info2, (mod, inst) => {
             receiveInstance(mod, inst);
-            resolve20(mod.exports);
+            resolve22(mod.exports);
           });
         });
       }

--- a/plugins/baoer-signal-grep/package.json
+++ b/plugins/baoer-signal-grep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer-signal-grep",
-  "version": "1.2.3",
+  "version": "1.2.3-1",
   "private": true,
   "type": "module",
   "omp": {

--- a/src/discovery-errors.ts
+++ b/src/discovery-errors.ts
@@ -1,0 +1,17 @@
+const FILE_DISCOVERY_QUERY_PLACEHOLDER = "<filename-or-path>";
+
+function repairQuery(value: unknown): string {
+  return typeof value === "string" &&
+    value.length <= 256 &&
+    value.isWellFormed() &&
+    !/[\r\n\0]/.test(value)
+    ? value
+    : FILE_DISCOVERY_QUERY_PLACEHOLDER;
+}
+
+export function fileDiscoveryQueryHint(value: unknown): string {
+  return `file discovery uses query; retry with ${JSON.stringify({ mode: "files", query: repairQuery(value) })}`;
+}
+
+export const DISCOVERY_MODE_REQUIRED_ERROR =
+  'query requires an explicit discovery mode: use mode=files for filename/path discovery or mode=concept for semantic discovery; for example {"mode":"files","query":"<filename-or-path>"}';

--- a/src/evidence-service.ts
+++ b/src/evidence-service.ts
@@ -1,4 +1,5 @@
 import { bindImpactCandidates } from "./impact-bindings.js";
+import { fileDiscoveryQueryHint } from "./discovery-errors.js";
 import { conceptSearch } from "./concept-search.js";
 import { structuralSearch } from "./structural-search.js";
 import { isSemanticMode } from "./semantic-protocol.js";
@@ -91,17 +92,16 @@ function rejectFields(
   fields: (keyof SignalGrepInput)[],
   operation: string,
   cursor = false,
+  hint = "copy the complete returned request",
 ): void {
   const present = fields.filter((field) => input[field] !== undefined);
   if (present.length)
     throw cursor
       ? new CursorError(
-          `${operation} does not accept ${present.join(", ")}; copy the complete returned request`,
+          `${operation} does not accept ${present.join(", ")}; ${hint}`,
           "E_CURSOR_OPTIONS_CONFLICT",
         )
-      : new SignalGrepError(
-          `${operation} does not accept ${present.join(", ")}; copy the complete returned request`,
-        );
+      : new SignalGrepError(`${operation} does not accept ${present.join(", ")}; ${hint}`);
 }
 const searchFields = [
   "query",
@@ -411,6 +411,8 @@ export class EvidenceService {
           ...inspectFields,
         ],
         "mode=files",
+        false,
+        fileDiscoveryQueryHint(input.query ?? input.pattern),
       );
       return this.#analyses.page(this.#analyses.create(await discoverFiles(input, cwd, signal)));
     }

--- a/src/file-discovery.ts
+++ b/src/file-discovery.ts
@@ -1,4 +1,4 @@
-import { posix } from "node:path";
+import { basename as platformBasename, posix, relative, resolve, sep } from "node:path";
 import type { AnalysisResultSet } from "./analysis-types.js";
 import { SignalGrepError } from "./errors.js";
 import { SearchPathPolicy } from "./path-policy.js";
@@ -49,6 +49,15 @@ export function scoreFilePath(path: string, query: string): FileScore | undefine
   };
 }
 
+function pathRelativeToDiscoveryRoot(cwd: string, root: string, path: string): string {
+  const absoluteRoot = resolve(cwd, root);
+  const absolutePath = resolve(cwd, path);
+  const scoped = relative(absoluteRoot, absolutePath).split(sep).join("/");
+  // A file can itself be the requested root; its basename is the only
+  // candidate path and must remain searchable without scoring the root name.
+  return scoped || platformBasename(absolutePath);
+}
+
 export async function discoverFiles(
   input: RawSearchInput & { query?: string },
   cwd: string,
@@ -60,8 +69,11 @@ export async function discoverFiles(
       "File query must be well-formed single-line text of at most 256 characters",
     );
   const request = normalizeRequest({ ...input, pattern: "" });
+  const policy = new SearchPathPolicy(cwd);
+  const discoveryRoot = request.path ?? ".";
+  const scoringRoot = await policy.resolveSearchTarget(discoveryRoot);
   const files = await listWorkspaceFiles(cwd, signal, {
-    ...(request.path ? { path: request.path } : {}),
+    path: scoringRoot,
     glob: request.glob,
     exclude: request.exclude,
     hidden: request.hidden,
@@ -75,11 +87,10 @@ export async function discoverFiles(
   );
   const selected = filtered.paths
     .flatMap((path) => {
-      const rank = scoreFilePath(path, query);
+      const rank = scoreFilePath(pathRelativeToDiscoveryRoot(cwd, scoringRoot, path), query);
       return rank ? [{ path, ...rank }] : [];
     })
     .toSorted((left, right) => right.score - left.score || left.path.localeCompare(right.path));
-  const policy = new SearchPathPolicy(cwd);
   for (let offset = 0; offset < selected.length; offset += 16) {
     // oxlint-disable-next-line no-await-in-loop -- bounded canonical-path checks enforce the same protected-path policy.
     await Promise.all(

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -9,7 +9,7 @@ import { URL as URL2 } from "node:url";
 // package.json
 var package_default = {
   name: "baoer_signal_grep",
-  version: "1.2.3",
+  version: "1.2.3-1",
   description: "Context-efficient local search for files, documents, notes and logs across Pi, OMP and MCP clients",
   keywords: [
     "ai-agent",
@@ -1638,7 +1638,7 @@ function executablePath() {
     throw new SignalGrepError(`TypeScript semantic provider is unavailable for ${process.platform}/${process.arch}; reinstall with optional dependencies enabled`, { cause: error });
   }
 }
-async function runTypeScript(cwd, documents, operation, parent) {
+async function runTypeScript(cwd, documents, operation, parent, sourceCwd = cwd) {
   const executable = executablePath();
   const deadline = new AbortController;
   const signal = parent ? AbortSignal.any([parent, deadline.signal]) : deadline.signal;
@@ -1675,7 +1675,7 @@ async function runTypeScript(cwd, documents, operation, parent) {
         settings: { "js/ts": preferences, typescript: preferences, javascript: preferences }
       });
       for (const document of documents) {
-        const uri = await semanticUri(cwd, document.path);
+        const uri = await semanticUri(sourceCwd, document.path);
         await channel.notify("textDocument/didOpen", {
           textDocument: {
             uri,
@@ -1700,8 +1700,8 @@ async function runTypeScript(cwd, documents, operation, parent) {
     clearTimeout(timer);
   }
 }
-function withTypeScript(cwd, documents, operation, parent) {
-  return compilerQueue.run(() => runTypeScript(cwd, documents, operation, parent), parent);
+function withTypeScript(cwd, documents, operation, parent, sourceCwd = cwd) {
+  return compilerQueue.run(() => runTypeScript(cwd, documents, operation, parent, sourceCwd), parent);
 }
 
 // src/syntax.ts
@@ -2386,6 +2386,16 @@ async function bindImpactCandidates(target, files, occurrences, access2) {
   }
   return { items: [...retained.values()], bound };
 }
+
+// src/discovery-errors.ts
+var FILE_DISCOVERY_QUERY_PLACEHOLDER = "<filename-or-path>";
+function repairQuery(value) {
+  return typeof value === "string" && value.length <= 256 && value.isWellFormed() && !/[\r\n\0]/.test(value) ? value : FILE_DISCOVERY_QUERY_PLACEHOLDER;
+}
+function fileDiscoveryQueryHint(value) {
+  return `file discovery uses query; retry with ${JSON.stringify({ mode: "files", query: repairQuery(value) })}`;
+}
+var DISCOVERY_MODE_REQUIRED_ERROR = 'query requires an explicit discovery mode: use mode=files for filename/path discovery or mode=concept for semantic discovery; for example {"mode":"files","query":"<filename-or-path>"}';
 
 // src/concept-search.ts
 import { dirname as dirname4 } from "node:path";
@@ -4163,20 +4173,87 @@ function rankEvidence(items, priority) {
 }
 
 // src/semantic-navigation.ts
-import { resolve as resolve13 } from "node:path";
+import { resolve as resolve14 } from "node:path";
 
 // src/semantic-project.ts
-import { resolve as resolve12 } from "node:path";
+import { resolve as resolve13 } from "node:path";
+
+// src/project-root.ts
+import { readdir, realpath as realpath5 } from "node:fs/promises";
+import { dirname as dirname5, relative as relative7, resolve as resolve12 } from "node:path";
+var TYPESCRIPT_CONFIG_FILE = /^[tj]sconfig[^/]*\.json$/i;
+function isMissingPath(error) {
+  return error instanceof Error && "code" in error && (error.code === "ENOENT" || error.code === "ENOTDIR");
+}
+async function projectConfig(directory, signal) {
+  if (signal?.aborted)
+    throw abortError();
+  try {
+    const entries = await readdir(directory, { withFileTypes: true });
+    const files = entries.filter((entry) => entry.isFile() || entry.isSymbolicLink());
+    if (files.some((entry) => TYPESCRIPT_CONFIG_FILE.test(entry.name)))
+      return "typescript";
+    if (files.some((entry) => entry.name.toLowerCase() === "package.json"))
+      return "package";
+    return;
+  } catch (error) {
+    if (isMissingPath(error))
+      return;
+    throw error;
+  }
+}
+async function gitRootWithinCwd(cwd, gitRoot) {
+  const absoluteCwd = resolve12(cwd);
+  const [canonicalCwd, canonicalRoot] = await Promise.all([
+    realpath5(absoluteCwd),
+    realpath5(gitRoot)
+  ]);
+  if (!isPathInsideCwd(canonicalRoot, canonicalCwd))
+    return;
+  return resolve12(absoluteCwd, relative7(canonicalCwd, canonicalRoot));
+}
+async function resolveSemanticProjectRoot(cwd, targetPath, signal) {
+  const absoluteCwd = resolve12(cwd);
+  const absoluteTarget = resolve12(absoluteCwd, targetPath);
+  if (!isPathInsideCwd(absoluteTarget, absoluteCwd))
+    return absoluteCwd;
+  const targetDirectory = dirname5(absoluteTarget);
+  const gitRoot = await findGitRepository(targetDirectory, signal);
+  if (gitRoot) {
+    const localGitRoot = await gitRootWithinCwd(absoluteCwd, gitRoot);
+    if (localGitRoot)
+      return localGitRoot;
+  }
+  let packageRoot;
+  let current = targetDirectory;
+  while (isPathInsideCwd(current, absoluteCwd)) {
+    const marker = await projectConfig(current, signal);
+    if (marker === "typescript")
+      return current;
+    if (marker === "package" && packageRoot === undefined)
+      packageRoot = current;
+    if (current === absoluteCwd)
+      break;
+    const parent = dirname5(current);
+    if (parent === current || !isPathInsideCwd(parent, absoluteCwd))
+      break;
+    current = parent;
+  }
+  return packageRoot ?? targetDirectory;
+}
+
+// src/semantic-project.ts
 async function semanticProject(access2, targetPath) {
-  const files = await listWorkspaceFiles(access2.cwd, access2.signal);
+  const root = await resolveSemanticProjectRoot(access2.cwd, targetPath, access2.signal);
+  const files = await listWorkspaceFiles(access2.cwd, access2.signal, { path: root });
   const paths = files.paths.filter((path) => {
     const language = syntaxLanguage(path);
     return language && language !== "go";
   });
-  const target = resolve12(access2.cwd, targetPath);
-  if (!paths.some((path) => resolve12(access2.cwd, path) === target))
+  const target = resolve13(access2.cwd, targetPath);
+  if (!paths.some((path) => resolve13(access2.cwd, path) === target))
     throw new SignalGrepError("Semantic target must be an admitted JS/TS workspace file under current ignore rules");
-  paths.sort((a, b) => Number(resolve12(access2.cwd, b) === target) - Number(resolve12(access2.cwd, a) === target) || a.localeCompare(b));
+  paths.sort((a, b) => Number(resolve13(access2.cwd, b) === target) - Number(resolve13(access2.cwd, a) === target) || a.localeCompare(b));
   const documents = new Map;
   const reasons = [...files.reasons];
   const metadata = [];
@@ -4189,7 +4266,7 @@ async function semanticProject(access2, targetPath) {
       if (!document.utf8)
         throw new SourceDocumentError("encoding", `Non-UTF-8 semantic source: ${path}`);
       if (paths.includes(path))
-        documents.set(resolve12(access2.cwd, path), document);
+        documents.set(resolve13(access2.cwd, path), document);
       else
         metadata.push(document);
     } catch (error) {
@@ -4211,7 +4288,7 @@ async function semanticProject(access2, targetPath) {
         throw new Error("Expected worktree semantic source");
       await access2.refresh(document.path, document.reference);
     }
-    const after = await listWorkspaceFiles(access2.cwd, access2.signal);
+    const after = await listWorkspaceFiles(access2.cwd, access2.signal, { path: root });
     if (JSON.stringify(after) !== JSON.stringify(files))
       throw new SignalGrepError("Workspace file set changed during semantic query; retry");
   };
@@ -4229,7 +4306,7 @@ async function semanticProject(access2, targetPath) {
     },
     stats: { filesEnumerated: paths.length, filesSkipped: paths.length - documents.size }
   };
-  return { documents, primary, result, recheck };
+  return { documents, primary, result, recheck, root };
 }
 
 // src/semantic-navigation.ts
@@ -4320,7 +4397,7 @@ async function runSemanticNavigation(input, access2) {
   if (!input.path || !isSemanticMode(input.mode))
     throw new SignalGrepError("Semantic navigation requires a mode and workspace path");
   const project = await semanticProject(access2, input.path);
-  const { result, documents, primary } = project;
+  const { result, documents, primary, root } = project;
   result.kind = input.mode;
   result.redact = input.redact ?? false;
   const mode = input.mode;
@@ -4338,7 +4415,7 @@ async function runSemanticNavigation(input, access2) {
       result.reasons.push("Compiler returned a location outside admitted source coverage; dependency/ignored/over-budget source was not exposed");
     }
   };
-  await withTypeScript(access2.cwd, [...documents.values()], async (channel) => {
+  await withTypeScript(root, [...documents.values()], async (channel) => {
     if (!graph) {
       const found = await queryLocations(channel, mode, {
         textDocument: { uri: await semanticUri(access2.cwd, primary.path) },
@@ -4383,7 +4460,7 @@ async function runSemanticNavigation(input, access2) {
             await add(target, "dependency");
           } else if (targetDocument === primary) {
             await add({
-              path: resolve13(access2.cwd, document.path),
+              path: resolve14(access2.cwd, document.path),
               range: {
                 start: lspPosition(document, specifier.start),
                 end: lspPosition(document, specifier.end)
@@ -4394,7 +4471,7 @@ async function runSemanticNavigation(input, access2) {
       }
       access2.releaseSyntax(document);
     }
-  }, access2.signal);
+  }, access2.signal, access2.cwd);
   await project.recheck();
   result.filesRead = access2.filesRead;
   result.bytesRead = access2.bytesRead;
@@ -4416,7 +4493,7 @@ function navigateSemantics(input, access2) {
 }
 
 // src/evidence-service.ts
-import { dirname as dirname5, resolve as resolve18 } from "node:path";
+import { dirname as dirname6, resolve as resolve20 } from "node:path";
 
 // src/analysis-store.ts
 import { randomUUID } from "node:crypto";
@@ -4745,7 +4822,7 @@ Inspect: ${JSON.stringify(inspect)}` : ""}`;
 }
 
 // src/inspect.ts
-import { resolve as resolve14 } from "node:path";
+import { resolve as resolve15 } from "node:path";
 function resolveInspectionTarget(input, cwd, snapshots) {
   let path = input.path?.replace(/^@/, "");
   let line = input.line;
@@ -4772,7 +4849,7 @@ function resolveInspectionTarget(input, cwd, snapshots) {
   if (line === undefined || !Number.isSafeInteger(line) || line < 1) {
     throw new SignalGrepError("line must be a positive integer when mode=inspect");
   }
-  const absolutePath = retainedMatch?.absolutePath ?? resolve14(cwd, path);
+  const absolutePath = retainedMatch?.absolutePath ?? resolve15(cwd, path);
   new SearchPathPolicy(cwd).assertPath(absolutePath);
   let expectedRevision;
   if (input.cursor) {
@@ -4794,7 +4871,7 @@ function resolveInspectionTarget(input, cwd, snapshots) {
 }
 
 // src/evidence-candidates.ts
-import { resolve as resolve15 } from "node:path";
+import { resolve as resolve16 } from "node:path";
 class CandidateLimit extends SignalGrepError {
 }
 function record(value) {
@@ -4956,7 +5033,7 @@ async function ordinaryCandidates(options) {
 async function collectEvidenceCandidates(options) {
   if (!options.changes)
     return ordinaryCandidates(options);
-  if (options.request.path && !isPathInsideCwd(resolve15(options.cwd, options.request.path), options.cwd)) {
+  if (options.request.path && !isPathInsideCwd(resolve16(options.cwd, options.request.path), options.cwd)) {
     throw new SignalGrepError("Git changes for paths outside cwd are not supported; relaunch Pi from that repository or a common parent");
   }
   const reasons = new Set;
@@ -6710,10 +6787,10 @@ async function runOwnedParallel(start, parent) {
 }
 
 // src/file-discovery.ts
-import { posix as posix4 } from "node:path";
+import { basename as platformBasename, posix as posix4, relative as relative8, resolve as resolve18, sep as sep4 } from "node:path";
 
 // src/file-metadata-filter.ts
-import { resolve as resolve16 } from "node:path";
+import { resolve as resolve17 } from "node:path";
 async function filterPathsByModificationTime(cwd, paths, modifiedAfterMs, modifiedBeforeMs, signal) {
   if (modifiedAfterMs === undefined && modifiedBeforeMs === undefined)
     return { paths: [...paths], partial: false, reasons: [] };
@@ -6724,7 +6801,7 @@ async function filterPathsByModificationTime(cwd, paths, modifiedAfterMs, modifi
       throw abortError();
     const batch = paths.slice(offset, offset + MAX_SOURCE_REVISION_CONCURRENCY);
     const revisions = await Promise.all(batch.map(async (path) => {
-      const revision = await getSourceRevision(resolve16(cwd, path));
+      const revision = await getSourceRevision(resolve17(cwd, path));
       return revision ? { path, revision } : { path };
     }));
     for (const { path, revision } of revisions) {
@@ -6780,23 +6857,31 @@ function scoreFilePath(path, query) {
     reason: "ordered fuzzy path characters; candidate, not an exact filename"
   };
 }
+function pathRelativeToDiscoveryRoot(cwd, root, path) {
+  const absoluteRoot = resolve18(cwd, root);
+  const absolutePath = resolve18(cwd, path);
+  const scoped = relative8(absoluteRoot, absolutePath).split(sep4).join("/");
+  return scoped || platformBasename(absolutePath);
+}
 async function discoverFiles(input, cwd, signal) {
   const query = input.query ?? "";
   if (query.length > 256 || !query.isWellFormed() || /[\r\n\0]/.test(query))
     throw new SignalGrepError("File query must be well-formed single-line text of at most 256 characters");
   const request = normalizeRequest({ ...input, pattern: "" });
+  const policy = new SearchPathPolicy(cwd);
+  const discoveryRoot = request.path ?? ".";
+  const scoringRoot = await policy.resolveSearchTarget(discoveryRoot);
   const files = await listWorkspaceFiles(cwd, signal, {
-    ...request.path ? { path: request.path } : {},
+    path: scoringRoot,
     glob: request.glob,
     exclude: request.exclude,
     hidden: request.hidden
   });
   const filtered = await filterPathsByModificationTime(cwd, files.paths, request.modifiedAfterMs, request.modifiedBeforeMs, signal);
   const selected = filtered.paths.flatMap((path) => {
-    const rank = scoreFilePath(path, query);
+    const rank = scoreFilePath(pathRelativeToDiscoveryRoot(cwd, scoringRoot, path), query);
     return rank ? [{ path, ...rank }] : [];
   }).toSorted((left, right) => right.score - left.score || left.path.localeCompare(right.path));
-  const policy = new SearchPathPolicy(cwd);
   for (let offset = 0;offset < selected.length; offset += 16) {
     await Promise.all(selected.slice(offset, offset + 16).map((item) => policy.assertExistingPath(item.path)));
     signal?.throwIfAborted();
@@ -7030,7 +7115,7 @@ class SourceContinuations {
 }
 
 // src/source-inspection.ts
-import { resolve as resolve17 } from "node:path";
+import { resolve as resolve19 } from "node:path";
 function legacySourceTarget(target) {
   return {
     path: target.path,
@@ -7096,7 +7181,7 @@ async function prepare(target, access2, structure) {
     }
   } else if (document.utf8 && structure && document.reference.origin.kind === "worktree" && !target.range) {
     const result = await structure.inspect({
-      absolutePath: resolve17(access2.cwd, target.path),
+      absolutePath: resolve19(access2.cwd, target.path),
       cwd: access2.cwd,
       line: target.line,
       expectedRevision: document.reference.origin.revision
@@ -7273,7 +7358,7 @@ ${preview.text}`);
     if (block.remaining.length)
       block.continuation = continuations.create(block.document.reference, block.ranges, block.remaining);
     if (block.document.reference.origin.kind === "worktree") {
-      const current = await getSourceRevision(resolve17(access2.cwd, block.document.path));
+      const current = await getSourceRevision(resolve19(access2.cwd, block.document.path));
       if (!current || !sameSourceRevision(current, block.document.reference.origin.revision)) {
         block.text = [];
         block.fragments = [];
@@ -7848,10 +7933,10 @@ function parsePythonOutline(document) {
 function isEvidenceRequest(input) {
   return isSemanticMode(input.mode) || input.mode === "concept" || input.mode === "structure" || input.mode === "files" || input.mode === "inspect" || input.mode === "outline" || input.mode === "imports" || input.mode === "tests" || input.mode === "impact" || input.sourceCursor !== undefined || input.anyOf !== undefined || input.allOf !== undefined || input.within !== undefined || input.roles !== undefined || input.changes !== undefined || input.symbol !== undefined || (input.cursor?.includes(".analysis") ?? false);
 }
-function rejectFields(input, fields, operation, cursor = false) {
+function rejectFields(input, fields, operation, cursor = false, hint = "copy the complete returned request") {
   const present = fields.filter((field) => input[field] !== undefined);
   if (present.length)
-    throw cursor ? new CursorError(`${operation} does not accept ${present.join(", ")}; copy the complete returned request`, "E_CURSOR_OPTIONS_CONFLICT") : new SignalGrepError(`${operation} does not accept ${present.join(", ")}; copy the complete returned request`);
+    throw cursor ? new CursorError(`${operation} does not accept ${present.join(", ")}; ${hint}`, "E_CURSOR_OPTIONS_CONFLICT") : new SignalGrepError(`${operation} does not accept ${present.join(", ")}; ${hint}`);
 }
 var searchFields = [
   "query",
@@ -7949,10 +8034,10 @@ function searchScope(request) {
   };
 }
 async function navigationRoot(cwd, path, signal) {
-  const absolute = resolve18(cwd, path);
+  const absolute = resolve20(cwd, path);
   if (isPathInsideCwd(absolute, cwd))
-    return resolve18(cwd);
-  return await findGitRepository(dirname5(absolute), signal) ?? dirname5(absolute);
+    return resolve20(cwd);
+  return await findGitRepository(dirname6(absolute), signal) ?? dirname6(absolute);
 }
 
 class EvidenceService {
@@ -8085,7 +8170,7 @@ class EvidenceService {
         "roles",
         "changes",
         ...inspectFields
-      ], "mode=files");
+      ], "mode=files", false, fileDiscoveryQueryHint(input.query ?? input.pattern));
       return this.#analyses.page(this.#analyses.create(await discoverFiles(input, cwd, signal)));
     }
     if (input.mode === "impact")
@@ -8412,14 +8497,14 @@ class EvidenceService {
       reasons.add("Related-test augmentation skipped: exact occurrences exhausted the shared analysis budget");
     } else {
       const files = await listWorkspaceFiles(access2.cwd, access2.signal, { path: root });
-      const allowed = new Set(files.paths.map((file) => resolve18(access2.cwd, file)));
-      const primaryPath = resolve18(access2.cwd, document.path);
+      const allowed = new Set(files.paths.map((file) => resolve20(access2.cwd, file)));
+      const primaryPath = resolve20(access2.cwd, document.path);
       const host = {
         cwd: access2.cwd,
         ...access2.signal ? { signal: access2.signal } : {},
         normalizePath: (file) => workspaceRelativePath(access2.cwd, file),
         load: async (file, expected) => {
-          const absolutePath = resolve18(access2.cwd, file);
+          const absolutePath = resolve20(access2.cwd, file);
           if (!allowed.has(absolutePath))
             throw new SignalGrepError("Navigation source is excluded by current ignore rules");
           if (absolutePath === primaryPath && expected === undefined)
@@ -8586,14 +8671,14 @@ class EvidenceService {
       }));
     const root = await navigationRoot(access2.cwd, document.path, access2.signal);
     const files = await listWorkspaceFiles(access2.cwd, access2.signal, { path: root });
-    const allowed = new Set(files.paths.map((file) => resolve18(access2.cwd, file)));
-    const primaryPath = resolve18(access2.cwd, document.path);
+    const allowed = new Set(files.paths.map((file) => resolve20(access2.cwd, file)));
+    const primaryPath = resolve20(access2.cwd, document.path);
     const host = {
       cwd: access2.cwd,
       ...access2.signal ? { signal: access2.signal } : {},
       normalizePath: (file) => workspaceRelativePath(access2.cwd, file),
       load: async (file, expected) => {
-        const absolutePath = resolve18(access2.cwd, file);
+        const absolutePath = resolve20(access2.cwd, file);
         if (!allowed.has(absolutePath))
           throw new SignalGrepError("Navigation source is excluded by current ignore rules");
         if (absolutePath === primaryPath && expected === undefined)
@@ -8634,7 +8719,7 @@ class EvidenceService {
 }
 
 // src/service.ts
-import { resolve as resolve19 } from "node:path";
+import { resolve as resolve21 } from "node:path";
 
 // src/format.ts
 import { readFile as readFile2 } from "node:fs/promises";
@@ -9227,7 +9312,7 @@ function cursorPathSelection(input, cwd) {
     validateSearchPath(label, input.paths !== undefined ? "paths" : "path");
     if (label.length === 0)
       throw new SignalGrepError("Cursor paths cannot be empty");
-    const absolutePath = resolve19(cwd, label);
+    const absolutePath = resolve21(cwd, label);
     policy.assertPath(absolutePath);
     if (absolutePaths.has(absolutePath))
       continue;
@@ -9409,7 +9494,7 @@ class SignalGrepService {
     if (input.column !== undefined)
       throw new SignalGrepError("column requires semantic navigation");
     if (input.query !== undefined)
-      throw new SignalGrepError("query requires a discovery mode");
+      throw new SignalGrepError(DISCOVERY_MODE_REQUIRED_ERROR);
     if (input.maxFilesToParse !== undefined) {
       throw new SignalGrepError("maxFilesToParse is only valid for structural analysis requests");
     }
@@ -10240,14 +10325,14 @@ async function startSignalGrepMcpServer(options = {}) {
   const host = options.host ?? DEFAULT_MCP_HOST;
   const port = options.port ?? DEFAULT_MCP_PORT;
   try {
-    await new Promise((resolve20, reject) => {
+    await new Promise((resolve22, reject) => {
       const onError = (error) => {
         httpServer.off("listening", onListening);
         reject(error);
       };
       const onListening = () => {
         httpServer.off("error", onError);
-        resolve20();
+        resolve22();
       };
       httpServer.once("error", onError);
       httpServer.once("listening", onListening);
@@ -10269,8 +10354,8 @@ async function startSignalGrepMcpServer(options = {}) {
     closePromise = (async () => {
       state.closing = true;
       clearInterval(sweepTimer);
-      const stopListening = new Promise((resolve20, reject) => {
-        httpServer.close((error) => error ? reject(error) : resolve20());
+      const stopListening = new Promise((resolve22, reject) => {
+        httpServer.close((error) => error ? reject(error) : resolve22());
       });
       const initialCleanup = await Promise.allSettled([
         ...[...state.ownedSessions].map((session) => cleanupOwnedSession(state, session)),

--- a/src/project-root.ts
+++ b/src/project-root.ts
@@ -1,0 +1,83 @@
+import { readdir, realpath } from "node:fs/promises";
+import { dirname, relative, resolve } from "node:path";
+import { abortError } from "./errors.js";
+import { findGitRepository } from "./git-repository.js";
+import { isPathInsideCwd } from "./path-policy.js";
+
+const TYPESCRIPT_CONFIG_FILE = /^[tj]sconfig[^/]*\.json$/i;
+
+function isMissingPath(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
+}
+
+async function projectConfig(
+  directory: string,
+  signal?: AbortSignal,
+): Promise<"typescript" | "package" | undefined> {
+  if (signal?.aborted) throw abortError();
+  try {
+    const entries = await readdir(directory, { withFileTypes: true });
+    const files = entries.filter((entry) => entry.isFile() || entry.isSymbolicLink());
+    if (files.some((entry) => TYPESCRIPT_CONFIG_FILE.test(entry.name))) return "typescript";
+    if (files.some((entry) => entry.name.toLowerCase() === "package.json")) return "package";
+    return undefined;
+  } catch (error) {
+    if (isMissingPath(error)) return undefined;
+    throw error;
+  }
+}
+
+async function gitRootWithinCwd(cwd: string, gitRoot: string): Promise<string | undefined> {
+  const absoluteCwd = resolve(cwd);
+  const [canonicalCwd, canonicalRoot] = await Promise.all([
+    realpath(absoluteCwd),
+    realpath(gitRoot),
+  ]);
+  if (!isPathInsideCwd(canonicalRoot, canonicalCwd)) return undefined;
+  return resolve(absoluteCwd, relative(canonicalCwd, canonicalRoot));
+}
+
+/**
+ * Resolve the smallest stable project boundary available for semantic work.
+ * Git remains the authoritative boundary when it is inside the requested cwd;
+ * otherwise the nearest TypeScript configuration, then package marker, or the
+ * target directory is used. TypeScript configuration takes precedence so a
+ * package manifest nested inside a configured workspace does not hide the
+ * workspace's compiler project. The cwd bound is retained so semantic
+ * navigation cannot widen an existing request into an unrelated parent
+ * workspace.
+ */
+export async function resolveSemanticProjectRoot(
+  cwd: string,
+  targetPath: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const absoluteCwd = resolve(cwd);
+  const absoluteTarget = resolve(absoluteCwd, targetPath);
+  if (!isPathInsideCwd(absoluteTarget, absoluteCwd)) return absoluteCwd;
+
+  const targetDirectory = dirname(absoluteTarget);
+  const gitRoot = await findGitRepository(targetDirectory, signal);
+  if (gitRoot) {
+    const localGitRoot = await gitRootWithinCwd(absoluteCwd, gitRoot);
+    if (localGitRoot) return localGitRoot;
+  }
+
+  let packageRoot: string | undefined;
+  let current = targetDirectory;
+  while (isPathInsideCwd(current, absoluteCwd)) {
+    // oxlint-disable-next-line no-await-in-loop -- nearest ancestor order is the project-boundary contract.
+    const marker = await projectConfig(current, signal);
+    if (marker === "typescript") return current;
+    if (marker === "package" && packageRoot === undefined) packageRoot = current;
+    if (current === absoluteCwd) break;
+    const parent = dirname(current);
+    if (parent === current || !isPathInsideCwd(parent, absoluteCwd)) break;
+    current = parent;
+  }
+  return packageRoot ?? targetDirectory;
+}

--- a/src/semantic-navigation.ts
+++ b/src/semantic-navigation.ts
@@ -144,7 +144,7 @@ async function runSemanticNavigation(input: SignalGrepInput, access: SourceAcces
   if (!input.path || !isSemanticMode(input.mode))
     throw new SignalGrepError("Semantic navigation requires a mode and workspace path");
   const project = await semanticProject(access, input.path);
-  const { result, documents, primary } = project;
+  const { result, documents, primary, root } = project;
   result.kind = input.mode;
   result.redact = input.redact ?? false;
   const mode = input.mode;
@@ -169,7 +169,7 @@ async function runSemanticNavigation(input: SignalGrepInput, access: SourceAcces
     }
   };
   await withTypeScript(
-    access.cwd,
+    root,
     [...documents.values()],
     async (channel) => {
       if (!graph) {
@@ -249,6 +249,7 @@ async function runSemanticNavigation(input: SignalGrepInput, access: SourceAcces
       }
     },
     access.signal,
+    access.cwd,
   );
   await project.recheck();
   result.filesRead = access.filesRead;

--- a/src/semantic-project.ts
+++ b/src/semantic-project.ts
@@ -1,6 +1,7 @@
 import { resolve } from "node:path";
 import type { AnalysisResultSet } from "./analysis-types.js";
 import { SignalGrepError } from "./errors.js";
+import { resolveSemanticProjectRoot } from "./project-root.js";
 import { SourceAccess, SourceBudgetError } from "./source-access.js";
 import { SourceDocumentError, type SourceDocument } from "./source-document.js";
 import { listWorkspaceFiles } from "./workspace-files.js";
@@ -8,7 +9,8 @@ import { syntaxLanguage } from "./syntax.js";
 
 /** Only admitted, verified worktree source can become executable navigation evidence. */
 export async function semanticProject(access: SourceAccess, targetPath: string) {
-  const files = await listWorkspaceFiles(access.cwd, access.signal);
+  const root = await resolveSemanticProjectRoot(access.cwd, targetPath, access.signal);
+  const files = await listWorkspaceFiles(access.cwd, access.signal, { path: root });
   const paths = files.paths.filter((path) => {
     const language = syntaxLanguage(path);
     return language && language !== "go";
@@ -58,7 +60,7 @@ export async function semanticProject(access: SourceAccess, targetPath: string) 
       // oxlint-disable-next-line no-await-in-loop -- reread each captured version without doubling retained source memory.
       await access.refresh(document.path, document.reference);
     }
-    const after = await listWorkspaceFiles(access.cwd, access.signal);
+    const after = await listWorkspaceFiles(access.cwd, access.signal, { path: root });
     if (JSON.stringify(after) !== JSON.stringify(files))
       throw new SignalGrepError("Workspace file set changed during semantic query; retry");
   };
@@ -76,5 +78,5 @@ export async function semanticProject(access: SourceAccess, targetPath: string) 
     },
     stats: { filesEnumerated: paths.length, filesSkipped: paths.length - documents.size },
   };
-  return { documents, primary, result, recheck };
+  return { documents, primary, result, recheck, root };
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -4,6 +4,7 @@ import type { GitChangeRequest } from "./git-source.js";
 import type { SyntaxRoleName } from "./syntax.js";
 import { resolve } from "node:path";
 import { CursorError, SignalGrepError } from "./errors.js";
+import { DISCOVERY_MODE_REQUIRED_ERROR } from "./discovery-errors.js";
 import { formatMatchPage, MatchPageSoftLimitError, type MatchPageOptions } from "./format.js";
 import { formatSummary } from "./summary.js";
 import { summarySourcePreviews } from "./summary-previews.js";
@@ -303,7 +304,7 @@ export class SignalGrepService {
     if (isEvidenceRequest(input)) return this.#evidence.search(input, cwd, signal);
     if (input.column !== undefined)
       throw new SignalGrepError("column requires semantic navigation");
-    if (input.query !== undefined) throw new SignalGrepError("query requires a discovery mode");
+    if (input.query !== undefined) throw new SignalGrepError(DISCOVERY_MODE_REQUIRED_ERROR);
     if (input.maxFilesToParse !== undefined) {
       throw new SignalGrepError("maxFilesToParse is only valid for structural analysis requests");
     }

--- a/src/typescript-client.ts
+++ b/src/typescript-client.ts
@@ -52,6 +52,7 @@ async function runTypeScript<T>(
   documents: readonly SourceDocument[],
   operation: (channel: JsonRpcChannel, capabilities: Record<string, unknown>) => Promise<T>,
   parent?: AbortSignal,
+  sourceCwd = cwd,
 ): Promise<T> {
   const executable = executablePath();
   const deadline = new AbortController();
@@ -93,7 +94,7 @@ async function runTypeScript<T>(
         });
         for (const document of documents) {
           // oxlint-disable-next-line no-await-in-loop -- canonical URIs prevent duplicate compiler identities for workspace symlinks.
-          const uri = await semanticUri(cwd, document.path);
+          const uri = await semanticUri(sourceCwd, document.path);
           // oxlint-disable-next-line no-await-in-loop -- ordered didOpen notifications install the verified source snapshot.
           await channel.notify("textDocument/didOpen", {
             textDocument: {
@@ -136,6 +137,10 @@ export function withTypeScript<T>(
   documents: readonly SourceDocument[],
   operation: (channel: JsonRpcChannel, capabilities: Record<string, unknown>) => Promise<T>,
   parent?: AbortSignal,
+  sourceCwd = cwd,
 ): Promise<T> {
-  return compilerQueue.run(() => runTypeScript(cwd, documents, operation, parent), parent);
+  return compilerQueue.run(
+    () => runTypeScript(cwd, documents, operation, parent, sourceCwd),
+    parent,
+  );
 }


### PR DESCRIPTION
## Change

Fixes #33, #34 and #35.

- Scope semantic snapshots and stability rechecks to the target project boundary, with Git-root, TypeScript-config, package-marker and target-directory resolution that never widens beyond the MCP cwd.
- Keep compiler project-root resolution separate from MCP-relative evidence paths, preserving nested workspace and package-export navigation.
- Make invalid discovery requests actionable, including a concrete `mode=files` plus `query` repair for safe single-line values.
- Rank filename candidates relative to the effective requested root, including canonical external and symlink roots.
- Release version `1.2.3-1`; keep all generated MCP and OMP artifacts aligned. README was intentionally not changed per request.

## Validation

- [x] `bun run check:local` — 348 pass, 1 designed concept skip, 0 fail
- [x] `bun run pack:check` — 121 files, 5.0 MB unpacked
- [x] `npm publish --dry-run --access public` — valid `baoer_signal_grep@1.2.3-1`
- [x] Targeted issue and semantic-navigation regressions, including symlink and Git-root cases
- [x] `git diff --check`, final diff and generated artifacts reviewed

## Compatibility and risks

No valid search request or result semantics change. No aliases or silent mode inference were added. Semantic scans remain bounded by the existing admission, source and cancellation rules; only the snapshot boundary is narrowed to the resolved target project.

## Documentation

- [x] Updated CHANGELOG.md; README intentionally unchanged
- [x] No private source, tests, internal documents, credentials or logs are included

## AI assistance

Implemented and validated by Codex using the GPT-5 family. The AI executed the checks listed above and reviewed the final diff; no separate human review was performed during this task.