### PR TITLE
fix: publish prerelease as latest npm tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,4 +60,4 @@ jobs:
       - name: Install npm with trusted publishing support
         run: npm install --global npm@11.15.0
       - name: Publish with npm provenance
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag latest


### PR DESCRIPTION
## Summary
- publish prerelease version 1.2.3-1 with an explicit latest dist-tag
- keep npm Trusted Publishing and provenance enabled

## Validation
- bun run check:local
- bun run pack:check

Fixes the failed v1.2.3-1 release publish step, which npm rejected without an explicit tag.