### PR TITLE
fix: recover oversized impact search lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.3-3] - 2026-09-07
+
+- Recover from oversized ripgrep match lines during impact and broad searches, retaining partial status and source diagnostics instead of aborting the search.
+
 ## [1.2.3-2] - 2026-09-06
 
 - Fix redaction coverage for suffixed and compound sensitive variable names, including service keys and access-token variants.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer_signal_grep",
-  "version": "1.2.3-2",
+  "version": "1.2.3-3",
   "description": "Context-efficient local search for files, documents, notes and logs across Pi, OMP and MCP clients",
   "keywords": [
     "ai-agent",

--- a/plugins/baoer-signal-grep/.claude-plugin/plugin.json
+++ b/plugins/baoer-signal-grep/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer-signal-grep",
-  "version": "1.2.3-2",
+  "version": "1.2.3-3",
   "description": "Require baoer_signal_grep for conventional local searches while keeping development tools available.",
   "author": {
     "name": "宝儿"

--- a/plugins/baoer-signal-grep/.codex-plugin/plugin.json
+++ b/plugins/baoer-signal-grep/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer-signal-grep",
-  "version": "1.2.3-2",
+  "version": "1.2.3-3",
   "description": "Require baoer_signal_grep for conventional local searches while keeping development tools available.",
   "author": {
     "name": "宝儿"

--- a/plugins/baoer-signal-grep/kimi.plugin.json
+++ b/plugins/baoer-signal-grep/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer-signal-grep",
-  "version": "1.2.3-2",
+  "version": "1.2.3-3",
   "description": "Require baoer_signal_grep for conventional local searches while keeping development tools available.",
   "author": {
     "name": "宝儿"

--- a/plugins/baoer-signal-grep/omp-extension.mjs
+++ b/plugins/baoer-signal-grep/omp-extension.mjs
@@ -265,36 +265,95 @@ class SearchRetention {
 }
 
 // src/capped-lines.ts
-import { StringDecoder } from "string_decoder";
+var MAX_DIAGNOSTIC_PREFIX_BYTES = 8 * 1024;
 async function consumeCappedLines(stream, onLine, options = {}) {
   const maxLineBytes = options.maxLineBytes ?? MAX_PROTOCOL_LINE_BYTES;
-  const decoder = new StringDecoder("utf8");
-  let buffer = "";
-  const consumeBuffer = (final) => {
-    let newline = buffer.indexOf(`
-`);
-    while (newline >= 0) {
-      const line = buffer.slice(0, newline).replace(/\r$/, "");
-      if (Buffer.byteLength(line, "utf8") > maxLineBytes) {
-        throw new Error(`Input line exceeds the ${String(maxLineBytes)}-byte limit`);
-      }
-      onLine(line);
-      buffer = buffer.slice(newline + 1);
-      newline = buffer.indexOf(`
-`);
+  if (!Number.isSafeInteger(maxLineBytes) || maxLineBytes < 1)
+    throw new Error("Capped line byte limit must be a positive safe integer");
+  let lineChunks = [];
+  let lineBytes = 0;
+  let discarding = false;
+  const resetLine = () => {
+    lineChunks = [];
+    lineBytes = 0;
+  };
+  const lastLineByte = () => {
+    const chunk = lineChunks.at(-1);
+    return chunk && chunk.length > 0 ? chunk[chunk.length - 1] : undefined;
+  };
+  const prefixFor = (segment, totalBytes) => {
+    const prefixBytes = Math.min(MAX_DIAGNOSTIC_PREFIX_BYTES, totalBytes);
+    const prefix = Buffer.allocUnsafe(prefixBytes);
+    let copied = 0;
+    for (const chunk of lineChunks) {
+      if (copied === prefixBytes)
+        break;
+      const length = Math.min(chunk.length, prefixBytes - copied);
+      prefix.set(chunk.subarray(0, length), copied);
+      copied += length;
     }
-    if (Buffer.byteLength(buffer, "utf8") > maxLineBytes) {
+    if (copied < prefixBytes) {
+      const length = Math.min(segment.length, prefixBytes - copied);
+      prefix.set(segment.subarray(0, length), copied);
+    }
+    return prefix.toString("utf8");
+  };
+  const lineText = (withoutTrailingCarriageReturn) => {
+    const contentBytes = lineBytes - (withoutTrailingCarriageReturn && lineBytes > 0 ? 1 : 0);
+    const bytes = Buffer.concat(lineChunks, lineBytes);
+    return bytes.toString("utf8", 0, contentBytes);
+  };
+  const reportOverflow = (segment, observedBytes, final) => {
+    if (!options.onLineTooLong)
       throw new Error(`Input line exceeds the ${String(maxLineBytes)}-byte limit${final ? " at end of stream" : ""}`);
+    options.onLineTooLong({
+      prefix: prefixFor(segment, observedBytes),
+      observedBytes
+    });
+  };
+  const consumeChunk = (chunk, final) => {
+    let offset = 0;
+    while (offset < chunk.length) {
+      const newline = chunk.indexOf(10, offset);
+      const end = newline >= 0 ? newline : chunk.length;
+      const segment = chunk.subarray(offset, end);
+      if (discarding) {
+        if (newline < 0)
+          return;
+        discarding = false;
+        resetLine();
+        offset = newline + 1;
+        continue;
+      }
+      const observedBytes = lineBytes + segment.length;
+      const hasTrailingCarriageReturn = newline >= 0 && observedBytes > 0 && (segment.at(-1) ?? lastLineByte()) === 13;
+      const contentBytes = observedBytes - (hasTrailingCarriageReturn ? 1 : 0);
+      if (contentBytes > maxLineBytes) {
+        reportOverflow(segment, observedBytes, final && newline < 0);
+        resetLine();
+        if (newline < 0)
+          discarding = true;
+        else
+          offset = newline + 1;
+        continue;
+      }
+      if (segment.length > 0)
+        lineChunks.push(segment);
+      lineBytes = observedBytes;
+      if (newline < 0)
+        return;
+      onLine(lineText(hasTrailingCarriageReturn));
+      resetLine();
+      offset = newline + 1;
     }
   };
-  for await (const chunk of stream) {
-    buffer += decoder.write(Buffer.from(chunk));
-    consumeBuffer(false);
-  }
-  buffer += decoder.end();
-  consumeBuffer(true);
-  if (buffer.length > 0)
-    onLine(buffer);
+  for await (const chunk of stream)
+    consumeChunk(chunk, false);
+  if (discarding)
+    return;
+  consumeChunk(new Uint8Array, true);
+  if (lineBytes > 0)
+    onLine(lineText(false));
 }
 
 // src/path-policy.ts
@@ -847,6 +906,75 @@ function displayPath(rawPath, cwd) {
     displayPath: isInsideCwd && localPath.length > 0 ? localPath : absolutePath
   };
 }
+function jsonObjectEnd(value, start2, end) {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = start2;index < end; index += 1) {
+    const character = value[index];
+    if (inString) {
+      if (escaped)
+        escaped = false;
+      else if (character === "\\")
+        escaped = true;
+      else if (character === '"')
+        inString = false;
+      continue;
+    }
+    if (character === '"') {
+      inString = true;
+      continue;
+    }
+    if (character === "{") {
+      depth += 1;
+      continue;
+    }
+    if (character !== "}")
+      continue;
+    depth -= 1;
+    if (depth === 0)
+      return index + 1;
+  }
+  return;
+}
+function jsonObjectStringProperty(value, property, pathStart) {
+  let offset = pathStart + '"path"'.length;
+  while (/\s/.test(value[offset] ?? ""))
+    offset += 1;
+  if (value[offset] !== ":")
+    return;
+  offset += 1;
+  while (/\s/.test(value[offset] ?? ""))
+    offset += 1;
+  if (value[offset] !== "{")
+    return;
+  const objectEnd = jsonObjectEnd(value, offset, value.length);
+  if (objectEnd === undefined)
+    return;
+  try {
+    const parsed = JSON.parse(value.slice(offset, objectEnd));
+    if (!isRecord(parsed))
+      return;
+    const candidate = parsed[property];
+    return typeof candidate === "string" ? candidate : undefined;
+  } catch {
+    return;
+  }
+}
+function oversizedMatchPath(prefix, cwd) {
+  const pathStart = prefix.indexOf('"path"');
+  if (pathStart < 0)
+    return;
+  const text = jsonObjectStringProperty(prefix, "text", pathStart);
+  if (text !== undefined)
+    return displayPath(text, cwd);
+  const encoded = jsonObjectStringProperty(prefix, "bytes", pathStart);
+  if (encoded === undefined)
+    return;
+  const bytes = Buffer.from(encoded, "base64");
+  const decoded = bytes.toString("utf8");
+  return Buffer.from(decoded, "utf8").equals(bytes) ? displayPath(decoded, cwd) : undefined;
+}
 async function assertSearchTargetIdentity(policy, path, expectedCanonical) {
   const currentCanonical = await policy.resolveExistingPath(path);
   if (currentCanonical !== expectedCanonical) {
@@ -960,6 +1088,7 @@ function createRipgrepRunner(options = {}) {
     const retention = new SearchRetention(options.maxStoredBytes, options.maxStoredOccurrences);
     const fileCounts = new Map;
     const lossyPaths = new Set;
+    const oversizedPathReasons = new Set;
     let totalMatches = 0;
     let truncatedLines = 0;
     let modificationTimeFilterIncomplete = false;
@@ -1040,7 +1169,17 @@ function createRipgrepRunner(options = {}) {
       ], cwd, maxSourceRevisionFiles, signal);
       candidateRevisions = before;
       await assertSearchTargetIdentity(policy, validatedSearchPath, expectedSearchTarget);
-      const { code, stderr } = await runOwnedProcess({ executable, args: args2, cwd, ...signal ? { signal } : {} }, (stdout) => consumeCappedLines(stdout, onLine, { maxLineBytes: maxEventBytes }));
+      const { code, stderr } = await runOwnedProcess({ executable, args: args2, cwd, ...signal ? { signal } : {} }, (stdout) => consumeCappedLines(stdout, onLine, {
+        maxLineBytes: maxEventBytes,
+        onLineTooLong: ({ prefix, observedBytes }) => {
+          const source = oversizedMatchPath(prefix, cwd);
+          const label = source?.displayPath ?? "unknown source";
+          if (oversizedPathReasons.has(label))
+            return;
+          oversizedPathReasons.add(label);
+          retention.noteLimit(`Skipped oversized ripgrep match line in ${JSON.stringify(label)}; observed at least ${String(observedBytes)} bytes, limit is ${String(maxEventBytes)} bytes`);
+        }
+      }));
       if (code !== 0 && code !== 1) {
         throw new SignalGrepError(stderr.trim() || `ripgrep exited with status ${String(code)}`);
       }
@@ -5016,8 +5155,11 @@ async function ordinaryCandidates(options) {
   if (options.signal?.aborted)
     throw abortError();
   const reasons = new Set;
-  if (!scan.snapshotComplete)
+  if (!scan.snapshotComplete) {
     reasons.add("Search retention is partial; only retained matching files can be analyzed");
+    for (const reason of scan.retention?.reasons ?? [])
+      reasons.add(reason);
+  }
   const grouped = new Map;
   for (const match of scan.matches) {
     const existing = grouped.get(match.absolutePath);

--- a/plugins/baoer-signal-grep/package.json
+++ b/plugins/baoer-signal-grep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer-signal-grep",
-  "version": "1.2.3-2",
+  "version": "1.2.3-3",
   "private": true,
   "type": "module",
   "omp": {

--- a/src/capped-lines.ts
+++ b/src/capped-lines.ts
@@ -1,8 +1,10 @@
-import { StringDecoder } from "node:string_decoder";
 import { MAX_PROTOCOL_LINE_BYTES } from "./types.js";
+
+const MAX_DIAGNOSTIC_PREFIX_BYTES = 8 * 1024;
 
 export interface CappedLineReaderOptions {
   maxLineBytes?: number;
+  onLineTooLong?: (details: { prefix: string; observedBytes: number }) => void;
 }
 
 /**
@@ -16,34 +18,95 @@ export async function consumeCappedLines(
   options: CappedLineReaderOptions = {},
 ): Promise<void> {
   const maxLineBytes = options.maxLineBytes ?? MAX_PROTOCOL_LINE_BYTES;
-  const decoder = new StringDecoder("utf8");
-  let buffer = "";
+  if (!Number.isSafeInteger(maxLineBytes) || maxLineBytes < 1)
+    throw new Error("Capped line byte limit must be a positive safe integer");
 
-  const consumeBuffer = (final: boolean) => {
-    let newline = buffer.indexOf("\n");
-    while (newline >= 0) {
-      const line = buffer.slice(0, newline).replace(/\r$/, "");
-      if (Buffer.byteLength(line, "utf8") > maxLineBytes) {
-        throw new Error(`Input line exceeds the ${String(maxLineBytes)}-byte limit`);
-      }
-      onLine(line);
-      buffer = buffer.slice(newline + 1);
-      newline = buffer.indexOf("\n");
+  let lineChunks: Uint8Array[] = [];
+  let lineBytes = 0;
+  let discarding = false;
+
+  const resetLine = () => {
+    lineChunks = [];
+    lineBytes = 0;
+  };
+
+  const lastLineByte = (): number | undefined => {
+    const chunk = lineChunks.at(-1);
+    return chunk && chunk.length > 0 ? chunk[chunk.length - 1] : undefined;
+  };
+
+  const prefixFor = (segment: Uint8Array, totalBytes: number): string => {
+    const prefixBytes = Math.min(MAX_DIAGNOSTIC_PREFIX_BYTES, totalBytes);
+    const prefix = Buffer.allocUnsafe(prefixBytes);
+    let copied = 0;
+    for (const chunk of lineChunks) {
+      if (copied === prefixBytes) break;
+      const length = Math.min(chunk.length, prefixBytes - copied);
+      prefix.set(chunk.subarray(0, length), copied);
+      copied += length;
     }
+    if (copied < prefixBytes) {
+      const length = Math.min(segment.length, prefixBytes - copied);
+      prefix.set(segment.subarray(0, length), copied);
+    }
+    return prefix.toString("utf8");
+  };
 
-    if (Buffer.byteLength(buffer, "utf8") > maxLineBytes) {
+  const lineText = (withoutTrailingCarriageReturn: boolean): string => {
+    const contentBytes = lineBytes - (withoutTrailingCarriageReturn && lineBytes > 0 ? 1 : 0);
+    const bytes = Buffer.concat(lineChunks, lineBytes);
+    return bytes.toString("utf8", 0, contentBytes);
+  };
+
+  const reportOverflow = (segment: Uint8Array, observedBytes: number, final: boolean): void => {
+    if (!options.onLineTooLong)
       throw new Error(
         `Input line exceeds the ${String(maxLineBytes)}-byte limit${final ? " at end of stream" : ""}`,
       );
+    options.onLineTooLong({
+      prefix: prefixFor(segment, observedBytes),
+      observedBytes,
+    });
+  };
+
+  const consumeChunk = (chunk: Uint8Array, final: boolean) => {
+    let offset = 0;
+    while (offset < chunk.length) {
+      const newline = chunk.indexOf(10, offset);
+      const end = newline >= 0 ? newline : chunk.length;
+      const segment = chunk.subarray(offset, end);
+
+      if (discarding) {
+        if (newline < 0) return;
+        discarding = false;
+        resetLine();
+        offset = newline + 1;
+        continue;
+      }
+
+      const observedBytes = lineBytes + segment.length;
+      const hasTrailingCarriageReturn =
+        newline >= 0 && observedBytes > 0 && (segment.at(-1) ?? lastLineByte()) === 13;
+      const contentBytes = observedBytes - (hasTrailingCarriageReturn ? 1 : 0);
+      if (contentBytes > maxLineBytes) {
+        reportOverflow(segment, observedBytes, final && newline < 0);
+        resetLine();
+        if (newline < 0) discarding = true;
+        else offset = newline + 1;
+        continue;
+      }
+
+      if (segment.length > 0) lineChunks.push(segment);
+      lineBytes = observedBytes;
+      if (newline < 0) return;
+      onLine(lineText(hasTrailingCarriageReturn));
+      resetLine();
+      offset = newline + 1;
     }
   };
 
-  for await (const chunk of stream) {
-    buffer += decoder.write(Buffer.from(chunk));
-    consumeBuffer(false);
-  }
-
-  buffer += decoder.end();
-  consumeBuffer(true);
-  if (buffer.length > 0) onLine(buffer);
+  for await (const chunk of stream) consumeChunk(chunk, false);
+  if (discarding) return;
+  consumeChunk(new Uint8Array(), true);
+  if (lineBytes > 0) onLine(lineText(false));
 }

--- a/src/evidence-candidates.ts
+++ b/src/evidence-candidates.ts
@@ -185,8 +185,10 @@ async function ordinaryCandidates(options: EvidenceCandidateOptions): Promise<Ev
   const scan = await options.runRipgrep(options.request, options.cwd, options.signal);
   if (options.signal?.aborted) throw abortError();
   const reasons = new Set<string>();
-  if (!scan.snapshotComplete)
+  if (!scan.snapshotComplete) {
     reasons.add("Search retention is partial; only retained matching files can be analyzed");
+    for (const reason of scan.retention?.reasons ?? []) reasons.add(reason);
+  }
   const grouped = new Map<string, typeof scan.matches>();
   for (const match of scan.matches) {
     const existing = grouped.get(match.absolutePath);

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -9,7 +9,7 @@ import { URL as URL2 } from "node:url";
 // package.json
 var package_default = {
   name: "baoer_signal_grep",
-  version: "1.2.3-2",
+  version: "1.2.3-3",
   description: "Context-efficient local search for files, documents, notes and logs across Pi, OMP and MCP clients",
   keywords: [
     "ai-agent",
@@ -305,36 +305,95 @@ class SearchRetention {
 }
 
 // src/capped-lines.ts
-import { StringDecoder } from "node:string_decoder";
+var MAX_DIAGNOSTIC_PREFIX_BYTES = 8 * 1024;
 async function consumeCappedLines(stream, onLine, options = {}) {
   const maxLineBytes = options.maxLineBytes ?? MAX_PROTOCOL_LINE_BYTES;
-  const decoder = new StringDecoder("utf8");
-  let buffer = "";
-  const consumeBuffer = (final) => {
-    let newline = buffer.indexOf(`
-`);
-    while (newline >= 0) {
-      const line = buffer.slice(0, newline).replace(/\r$/, "");
-      if (Buffer.byteLength(line, "utf8") > maxLineBytes) {
-        throw new Error(`Input line exceeds the ${String(maxLineBytes)}-byte limit`);
-      }
-      onLine(line);
-      buffer = buffer.slice(newline + 1);
-      newline = buffer.indexOf(`
-`);
+  if (!Number.isSafeInteger(maxLineBytes) || maxLineBytes < 1)
+    throw new Error("Capped line byte limit must be a positive safe integer");
+  let lineChunks = [];
+  let lineBytes = 0;
+  let discarding = false;
+  const resetLine = () => {
+    lineChunks = [];
+    lineBytes = 0;
+  };
+  const lastLineByte = () => {
+    const chunk = lineChunks.at(-1);
+    return chunk && chunk.length > 0 ? chunk[chunk.length - 1] : undefined;
+  };
+  const prefixFor = (segment, totalBytes) => {
+    const prefixBytes = Math.min(MAX_DIAGNOSTIC_PREFIX_BYTES, totalBytes);
+    const prefix = Buffer.allocUnsafe(prefixBytes);
+    let copied = 0;
+    for (const chunk of lineChunks) {
+      if (copied === prefixBytes)
+        break;
+      const length = Math.min(chunk.length, prefixBytes - copied);
+      prefix.set(chunk.subarray(0, length), copied);
+      copied += length;
     }
-    if (Buffer.byteLength(buffer, "utf8") > maxLineBytes) {
+    if (copied < prefixBytes) {
+      const length = Math.min(segment.length, prefixBytes - copied);
+      prefix.set(segment.subarray(0, length), copied);
+    }
+    return prefix.toString("utf8");
+  };
+  const lineText = (withoutTrailingCarriageReturn) => {
+    const contentBytes = lineBytes - (withoutTrailingCarriageReturn && lineBytes > 0 ? 1 : 0);
+    const bytes = Buffer.concat(lineChunks, lineBytes);
+    return bytes.toString("utf8", 0, contentBytes);
+  };
+  const reportOverflow = (segment, observedBytes, final) => {
+    if (!options.onLineTooLong)
       throw new Error(`Input line exceeds the ${String(maxLineBytes)}-byte limit${final ? " at end of stream" : ""}`);
+    options.onLineTooLong({
+      prefix: prefixFor(segment, observedBytes),
+      observedBytes
+    });
+  };
+  const consumeChunk = (chunk, final) => {
+    let offset = 0;
+    while (offset < chunk.length) {
+      const newline = chunk.indexOf(10, offset);
+      const end = newline >= 0 ? newline : chunk.length;
+      const segment = chunk.subarray(offset, end);
+      if (discarding) {
+        if (newline < 0)
+          return;
+        discarding = false;
+        resetLine();
+        offset = newline + 1;
+        continue;
+      }
+      const observedBytes = lineBytes + segment.length;
+      const hasTrailingCarriageReturn = newline >= 0 && observedBytes > 0 && (segment.at(-1) ?? lastLineByte()) === 13;
+      const contentBytes = observedBytes - (hasTrailingCarriageReturn ? 1 : 0);
+      if (contentBytes > maxLineBytes) {
+        reportOverflow(segment, observedBytes, final && newline < 0);
+        resetLine();
+        if (newline < 0)
+          discarding = true;
+        else
+          offset = newline + 1;
+        continue;
+      }
+      if (segment.length > 0)
+        lineChunks.push(segment);
+      lineBytes = observedBytes;
+      if (newline < 0)
+        return;
+      onLine(lineText(hasTrailingCarriageReturn));
+      resetLine();
+      offset = newline + 1;
     }
   };
-  for await (const chunk of stream) {
-    buffer += decoder.write(Buffer.from(chunk));
-    consumeBuffer(false);
-  }
-  buffer += decoder.end();
-  consumeBuffer(true);
-  if (buffer.length > 0)
-    onLine(buffer);
+  for await (const chunk of stream)
+    consumeChunk(chunk, false);
+  if (discarding)
+    return;
+  consumeChunk(new Uint8Array, true);
+  if (lineBytes > 0)
+    onLine(lineText(false));
 }
 
 // src/path-policy.ts
@@ -887,6 +946,75 @@ function displayPath(rawPath, cwd) {
     displayPath: isInsideCwd && localPath.length > 0 ? localPath : absolutePath
   };
 }
+function jsonObjectEnd(value, start, end) {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = start;index < end; index += 1) {
+    const character = value[index];
+    if (inString) {
+      if (escaped)
+        escaped = false;
+      else if (character === "\\")
+        escaped = true;
+      else if (character === '"')
+        inString = false;
+      continue;
+    }
+    if (character === '"') {
+      inString = true;
+      continue;
+    }
+    if (character === "{") {
+      depth += 1;
+      continue;
+    }
+    if (character !== "}")
+      continue;
+    depth -= 1;
+    if (depth === 0)
+      return index + 1;
+  }
+  return;
+}
+function jsonObjectStringProperty(value, property, pathStart) {
+  let offset = pathStart + '"path"'.length;
+  while (/\s/.test(value[offset] ?? ""))
+    offset += 1;
+  if (value[offset] !== ":")
+    return;
+  offset += 1;
+  while (/\s/.test(value[offset] ?? ""))
+    offset += 1;
+  if (value[offset] !== "{")
+    return;
+  const objectEnd = jsonObjectEnd(value, offset, value.length);
+  if (objectEnd === undefined)
+    return;
+  try {
+    const parsed = JSON.parse(value.slice(offset, objectEnd));
+    if (!isRecord(parsed))
+      return;
+    const candidate = parsed[property];
+    return typeof candidate === "string" ? candidate : undefined;
+  } catch {
+    return;
+  }
+}
+function oversizedMatchPath(prefix, cwd) {
+  const pathStart = prefix.indexOf('"path"');
+  if (pathStart < 0)
+    return;
+  const text = jsonObjectStringProperty(prefix, "text", pathStart);
+  if (text !== undefined)
+    return displayPath(text, cwd);
+  const encoded = jsonObjectStringProperty(prefix, "bytes", pathStart);
+  if (encoded === undefined)
+    return;
+  const bytes = Buffer.from(encoded, "base64");
+  const decoded = bytes.toString("utf8");
+  return Buffer.from(decoded, "utf8").equals(bytes) ? displayPath(decoded, cwd) : undefined;
+}
 async function assertSearchTargetIdentity(policy, path, expectedCanonical) {
   const currentCanonical = await policy.resolveExistingPath(path);
   if (currentCanonical !== expectedCanonical) {
@@ -1000,6 +1128,7 @@ function createRipgrepRunner(options = {}) {
     const retention = new SearchRetention(options.maxStoredBytes, options.maxStoredOccurrences);
     const fileCounts = new Map;
     const lossyPaths = new Set;
+    const oversizedPathReasons = new Set;
     let totalMatches = 0;
     let truncatedLines = 0;
     let modificationTimeFilterIncomplete = false;
@@ -1080,7 +1209,17 @@ function createRipgrepRunner(options = {}) {
       ], cwd, maxSourceRevisionFiles, signal);
       candidateRevisions = before;
       await assertSearchTargetIdentity(policy, validatedSearchPath, expectedSearchTarget);
-      const { code, stderr } = await runOwnedProcess({ executable, args, cwd, ...signal ? { signal } : {} }, (stdout) => consumeCappedLines(stdout, onLine, { maxLineBytes: maxEventBytes }));
+      const { code, stderr } = await runOwnedProcess({ executable, args, cwd, ...signal ? { signal } : {} }, (stdout) => consumeCappedLines(stdout, onLine, {
+        maxLineBytes: maxEventBytes,
+        onLineTooLong: ({ prefix, observedBytes }) => {
+          const source = oversizedMatchPath(prefix, cwd);
+          const label = source?.displayPath ?? "unknown source";
+          if (oversizedPathReasons.has(label))
+            return;
+          oversizedPathReasons.add(label);
+          retention.noteLimit(`Skipped oversized ripgrep match line in ${JSON.stringify(label)}; observed at least ${String(observedBytes)} bytes, limit is ${String(maxEventBytes)} bytes`);
+        }
+      }));
       if (code !== 0 && code !== 1) {
         throw new SignalGrepError(stderr.trim() || `ripgrep exited with status ${String(code)}`);
       }
@@ -4977,8 +5116,11 @@ async function ordinaryCandidates(options) {
   if (options.signal?.aborted)
     throw abortError();
   const reasons = new Set;
-  if (!scan.snapshotComplete)
+  if (!scan.snapshotComplete) {
     reasons.add("Search retention is partial; only retained matching files can be analyzed");
+    for (const reason of scan.retention?.reasons ?? [])
+      reasons.add(reason);
+  }
   const grouped = new Map;
   for (const match of scan.matches) {
     const existing = grouped.get(match.absolutePath);

--- a/src/rg.ts
+++ b/src/rg.ts
@@ -110,6 +110,70 @@ function displayPath(rawPath: string, cwd: string): { absolutePath: string; disp
     displayPath: isInsideCwd && localPath.length > 0 ? localPath : absolutePath,
   };
 }
+function jsonObjectEnd(value: string, start: number, end: number): number | undefined {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = start; index < end; index += 1) {
+    const character = value[index];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') inString = false;
+      continue;
+    }
+    if (character === '"') {
+      inString = true;
+      continue;
+    }
+    if (character === "{") {
+      depth += 1;
+      continue;
+    }
+    if (character !== "}") continue;
+    depth -= 1;
+    if (depth === 0) return index + 1;
+  }
+  return undefined;
+}
+
+function jsonObjectStringProperty(
+  value: string,
+  property: string,
+  pathStart: number,
+): string | undefined {
+  let offset = pathStart + '"path"'.length;
+  while (/\s/.test(value[offset] ?? "")) offset += 1;
+  if (value[offset] !== ":") return undefined;
+  offset += 1;
+  while (/\s/.test(value[offset] ?? "")) offset += 1;
+  if (value[offset] !== "{") return undefined;
+  const objectEnd = jsonObjectEnd(value, offset, value.length);
+  if (objectEnd === undefined) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(value.slice(offset, objectEnd));
+    if (!isRecord(parsed)) return undefined;
+    const candidate = parsed[property];
+    return typeof candidate === "string" ? candidate : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function oversizedMatchPath(
+  prefix: string,
+  cwd: string,
+): { absolutePath: string; displayPath: string } | undefined {
+  const pathStart = prefix.indexOf('"path"');
+  if (pathStart < 0) return undefined;
+  const text = jsonObjectStringProperty(prefix, "text", pathStart);
+  if (text !== undefined) return displayPath(text, cwd);
+  const encoded = jsonObjectStringProperty(prefix, "bytes", pathStart);
+  if (encoded === undefined) return undefined;
+  const bytes = Buffer.from(encoded, "base64");
+  const decoded = bytes.toString("utf8");
+  return Buffer.from(decoded, "utf8").equals(bytes) ? displayPath(decoded, cwd) : undefined;
+}
 
 async function assertSearchTargetIdentity(
   policy: SearchPathPolicy,
@@ -268,6 +332,7 @@ export function createRipgrepRunner(options: RipgrepRunnerOptions = {}) {
     const retention = new SearchRetention(options.maxStoredBytes, options.maxStoredOccurrences);
     const fileCounts = new Map<string, number>();
     const lossyPaths = new Set<string>();
+    const oversizedPathReasons = new Set<string>();
     let totalMatches = 0;
     let truncatedLines = 0;
     let modificationTimeFilterIncomplete = false;
@@ -361,7 +426,19 @@ export function createRipgrepRunner(options: RipgrepRunnerOptions = {}) {
       await assertSearchTargetIdentity(policy, validatedSearchPath, expectedSearchTarget);
       const { code, stderr } = await runOwnedProcess(
         { executable, args, cwd, ...(signal ? { signal } : {}) },
-        (stdout) => consumeCappedLines(stdout, onLine, { maxLineBytes: maxEventBytes }),
+        (stdout) =>
+          consumeCappedLines(stdout, onLine, {
+            maxLineBytes: maxEventBytes,
+            onLineTooLong: ({ prefix, observedBytes }) => {
+              const source = oversizedMatchPath(prefix, cwd);
+              const label = source?.displayPath ?? "unknown source";
+              if (oversizedPathReasons.has(label)) return;
+              oversizedPathReasons.add(label);
+              retention.noteLimit(
+                `Skipped oversized ripgrep match line in ${JSON.stringify(label)}; observed at least ${String(observedBytes)} bytes, limit is ${String(maxEventBytes)} bytes`,
+              );
+            },
+          }),
       );
       if (code !== 0 && code !== 1) {
         throw new SignalGrepError(stderr.trim() || `ripgrep exited with status ${String(code)}`);


### PR DESCRIPTION
## Change

Issue #42: a single ripgrep match line larger than 16 MiB aborted impact analysis. The reader now discards oversized ripgrep match lines through LF, continues the scan, records the source diagnostic, and exposes an explicit partial result while retaining other evidence. Strict behavior remains for unrelated line-reader callers. Release version is 1.2.3-3.

## Validation

- [x] bun run check:local (348 passed, 1 skipped, 0 failed)
- [x] bun run pack:check
- [x] Reviewed the final diff and generated MCP/OMP artifacts
- [x] Reproduced the 16 MiB+ impact case and verified partial status, retained caller evidence, and source diagnostics

## Compatibility and risks

The new recovery callback is opt-in. An incomplete ripgrep snapshot is never presented as complete; snapshotComplete=false and retention reasons are preserved. A bounded 8 KiB diagnostic prefix limits memory use.

## Documentation

- [x] Updated CHANGELOG.md
- [x] No private source, tests, internal documents, credentials or logs are included

## AI assistance

OpenAI Codex performed the implementation, focused tests, full local quality gates, generated-artifact checks, and differential review. The final diff was reviewed against the repository contracts and issue reproduction.