### PR TITLE
fix: reduce MCP model output duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.3-7] - 2026-09-08
+
+- Add opt-in MCP text and model output modes for hosts that serialize both readable and structured results into model context. Model mode selects the smaller of the standard page and a compact analysis view without repeated paths, inspect requests or outline excerpts while preserving counts, coverage, partial state and continuations; the existing structured result remains the default.
+
 ## [1.2.3-6] - 2026-09-08
 
 - Expose bounded Concept score profiles so broad candidate results remain distinguishable without treating similarity as a relevance threshold.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ codex mcp add baoer_signal_grep -- npx -y --package baoer_signal_grep@latest bao
 
 `@latest` follows the newest published version when MCP starts. Restart the host to load updates. The server searches the active project; `BAOER_SIGNAL_GREP_MCP_CWD` can select a different root. An MCP-only connection adds the tool without disabling other search tools.
 
+MCP returns readable text plus structured evidence by default. If a host serializes both forms into the model context, set `BAOER_SIGNAL_GREP_MCP_OUTPUT_MODE=model` in that MCP server's environment and restart it. Model mode omits `structuredContent` and its advertised output schema. It selects the smaller of the standard page and a compact view of the same retained analysis snapshot: repeated paths and inspect requests are shared, and outline excerpts are deferred to version-checked inspection. Counts, coverage, partial status, reasons and continuation requests remain visible. Use `text` to omit structured output while preserving the complete standard text, or retain the default `structured` mode for programmatic consumers and clients that expose only structured results. Any other value fails at startup. The bundled Claude Code, Codex and Kimi native plugins select `model`; direct MCP connections retain the compatible default unless configured explicitly.
+
 ### Native plugins
 
 For conventional search enforcement in other hosts:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -91,6 +91,8 @@ codex mcp add baoer_signal_grep -- npx -y --package baoer_signal_grep@latest bao
 
 `@latest` 会在 MCP 启动时跟随最新发布版本，更新后重启宿主即可加载。服务器默认搜索当前项目，可用 `BAOER_SIGNAL_GREP_MCP_CWD` 指定其他根目录。仅连接 MCP 会添加工具，不会禁用其他搜索工具。
 
+MCP 默认同时返回可读文本和结构化证据。如果宿主会把两种形式一起序列化进模型上下文，请在该 MCP 服务的环境中设置 `BAOER_SIGNAL_GREP_MCP_OUTPUT_MODE=model`，然后重启。模型模式不返回 `structuredContent`，也不声明结构化输出 schema；它会在标准页和同一个已保留分析快照的紧凑视图中选择较小者。紧凑视图共享重复路径和 inspect 请求，并把 outline 签名延后到版本校验过的源码检查。计数、覆盖范围、部分状态、原因和续读请求仍然可见。`text` 模式只省略结构化输出，逐字保留标准文本；程序消费者或只展示结构化结果的客户端应继续使用默认的 `structured` 模式。其他取值会在启动时明确失败。捆绑的 Claude Code、Codex 和 Kimi 原生插件会选择 `model`；直接 MCP 连接仍保留兼容默认值，除非显式配置。
+
 ### 原生插件
 
 如果希望在其他宿主中也强制常规搜索使用本插件：

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer_signal_grep",
-  "version": "1.2.3-6",
+  "version": "1.2.3-7",
   "description": "Context-efficient local search for files, documents, notes and logs across Pi, OMP and MCP clients",
   "keywords": [
     "ai-agent",

--- a/plugins/baoer-signal-grep/.claude-plugin/plugin.json
+++ b/plugins/baoer-signal-grep/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer-signal-grep",
-  "version": "1.2.3-6",
+  "version": "1.2.3-7",
   "description": "Require baoer_signal_grep for conventional local searches while keeping development tools available.",
   "author": {
     "name": "宝儿"

--- a/plugins/baoer-signal-grep/.codex-plugin/plugin.json
+++ b/plugins/baoer-signal-grep/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer-signal-grep",
-  "version": "1.2.3-6",
+  "version": "1.2.3-7",
   "description": "Require baoer_signal_grep for conventional local searches while keeping development tools available.",
   "author": {
     "name": "宝儿"

--- a/plugins/baoer-signal-grep/.mcp.json
+++ b/plugins/baoer-signal-grep/.mcp.json
@@ -11,7 +11,8 @@
       ],
       "env": {
         "npm_config_ignore_scripts": "true",
-        "ONNXRUNTIME_NODE_INSTALL_CUDA": "skip"
+        "ONNXRUNTIME_NODE_INSTALL_CUDA": "skip",
+        "BAOER_SIGNAL_GREP_MCP_OUTPUT_MODE": "model"
       }
     }
   }

--- a/plugins/baoer-signal-grep/kimi.plugin.json
+++ b/plugins/baoer-signal-grep/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer-signal-grep",
-  "version": "1.2.3-6",
+  "version": "1.2.3-7",
   "description": "Require baoer_signal_grep for conventional local searches while keeping development tools available.",
   "author": {
     "name": "宝儿"
@@ -19,7 +19,8 @@
       ],
       "env": {
         "npm_config_ignore_scripts": "true",
-        "ONNXRUNTIME_NODE_INSTALL_CUDA": "skip"
+        "ONNXRUNTIME_NODE_INSTALL_CUDA": "skip",
+        "BAOER_SIGNAL_GREP_MCP_OUTPUT_MODE": "model"
       }
     }
   },

--- a/plugins/baoer-signal-grep/omp-extension.mjs
+++ b/plugins/baoer-signal-grep/omp-extension.mjs
@@ -4834,6 +4834,7 @@ function analysisTermPage(result, id, offset) {
         termCountsOffset: offset,
         totalTerms: all.length,
         ...nextRequest ? { termCountsNextRequest: nextRequest } : {},
+        matchesRequest,
         ...result.coverage ? { coverage: result.coverage } : {}
       }
     }
@@ -10137,7 +10138,7 @@ Next request: ${JSON.stringify({ cursor, ...selectedPaths ? { paths: selectedPat
 }
 
 // src/prompt-guidelines.ts
-function signalGrepPromptGuidelines() {
+function signalGrepPromptGuidelines(structuredOutput = true) {
   return [
     `Use baoer_signal_grep for content search. Start with pattern and optional path; omit mode and limit to let auto choose a complete small result or a broad summary. Use literal=true for literal code fragments rather than escaping them as regex.`,
     `An omitted path searches the project cwd. Use scope:"strict" for a question restricted to one path; otherwise, if an explicit subpath has zero matches, ordinary and content-analysis searches retry from cwd and return project-wide matches with an expansion notice. Explicit absolute paths and .. traversal can search outside cwd, except protected external system areas and .git internals. Git changes mode remains cwd-scoped.`,
@@ -10155,7 +10156,7 @@ function signalGrepPromptGuidelines() {
     `Use mode:"structure" plus an ast-grep pattern such as "compare($X, $X)" or "send()" for code shapes across whitespace; no literal/regex or scope options. Use path/glob/exclude to narrow admitted syntax.`,
     `Use mode:"concept" plus a natural-language query when names are unknown. It runs a pinned local multilingual model only after explicit installation; no search downloads weights or sends code to a remote model. Similarity scores identify source candidates, not proof. File/concept/structure discovery never expands its requested path.`,
     `If inspection reports missing source, execute its complete nextRequest with sourceCursor. Never treat a partial source excerpt as the complete implementation.`,
-    `When status=partial, read details.analysis.coverage to see which conclusion is incomplete; an exact occurrence count may remain complete even when syntax or related-test analysis is partial.`
+    structuredOutput ? `When status=partial, read details.analysis.coverage to see which conclusion is incomplete; an exact occurrence count may remain complete even when syntax or related-test analysis is partial.` : `When status=partial, read the visible Coverage and bracketed reasons to see which conclusion is incomplete; an exact occurrence count may remain complete even when syntax or related-test analysis is partial.`
   ];
 }
 

--- a/plugins/baoer-signal-grep/package.json
+++ b/plugins/baoer-signal-grep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer-signal-grep",
-  "version": "1.2.3-6",
+  "version": "1.2.3-7",
   "private": true,
   "type": "module",
   "omp": {

--- a/scripts/search-policy-artifact.ts
+++ b/scripts/search-policy-artifact.ts
@@ -83,7 +83,11 @@ export async function buildSearchPlugin(root: string): Promise<void> {
         "baoer_signal_grep_mcp",
         "--stdio",
       ],
-      env: { npm_config_ignore_scripts: "true", ONNXRUNTIME_NODE_INSTALL_CUDA: "skip" },
+      env: {
+        npm_config_ignore_scripts: "true",
+        ONNXRUNTIME_NODE_INSTALL_CUDA: "skip",
+        BAOER_SIGNAL_GREP_MCP_OUTPUT_MODE: "model",
+      },
     },
   };
   const files: Record<string, unknown> = {

--- a/src/analysis-term-pages.ts
+++ b/src/analysis-term-pages.ts
@@ -64,6 +64,7 @@ export function analysisTermPage(
         termCountsOffset: offset,
         totalTerms: all.length,
         ...(nextRequest ? { termCountsNextRequest: nextRequest } : {}),
+        matchesRequest,
         ...(result.coverage ? { coverage: result.coverage } : {}),
       },
     },

--- a/src/analysis-types.ts
+++ b/src/analysis-types.ts
@@ -65,6 +65,7 @@ export interface AnalysisDetails {
   termCountsOffset?: number;
   totalTerms?: number;
   termCountsNextRequest?: SignalGrepInput;
+  matchesRequest?: SignalGrepInput;
   changes?: { base: string; target: string; scope: string; side: string };
   scope?: SearchScopeDetails;
   chunks?: {

--- a/src/mcp-model-output.ts
+++ b/src/mcp-model-output.ts
@@ -1,0 +1,93 @@
+import type { AnalysisDetails } from "./analysis-types.js";
+import type { SignalGrepDetails, SignalGrepResult } from "./types.js";
+
+function compactMetadata(details: SignalGrepDetails, analysis: AnalysisDetails): string[] {
+  return [
+    analysis.counts ? `Counts: ${JSON.stringify(analysis.counts)}` : undefined,
+    analysis.termCounts ? `Term counts: ${JSON.stringify(analysis.termCounts)}` : undefined,
+    analysis.termCountsNextRequest
+      ? `More term counts: ${JSON.stringify(analysis.termCountsNextRequest)}`
+      : undefined,
+    analysis.matchesRequest
+      ? `Matches request: ${JSON.stringify(analysis.matchesRequest)}`
+      : undefined,
+    analysis.changes ? `Changes: ${JSON.stringify(analysis.changes)}` : undefined,
+    analysis.scope ? `Scope: ${JSON.stringify(analysis.scope)}` : undefined,
+    analysis.chunks ? `Chunks: ${JSON.stringify(analysis.chunks)}` : undefined,
+    analysis.coverage ? `Coverage: ${JSON.stringify(analysis.coverage)}` : undefined,
+    analysis.stats ? `Stats: ${JSON.stringify(analysis.stats)}` : undefined,
+    analysis.kind === "outline"
+      ? "[Outline signatures are deferred; inspect item #N for version-checked source.]"
+      : undefined,
+    ...analysis.reasons.map((reason) => `[${reason}]`),
+    details.redactionApplied ? "[Display redaction applied.]" : undefined,
+  ].filter((line): line is string => line !== undefined);
+}
+
+function compactRows(analysis: AnalysisDetails): string[] {
+  const omitExcerpt = analysis.kind === "outline";
+  const rows: string[] = [];
+  let previousPath: string | undefined;
+  for (const item of analysis.items) {
+    if (item.path !== previousPath) {
+      rows.push(JSON.stringify(item.path));
+      previousPath = item.path;
+    }
+    const row = `#${String(item.index)} L${String(item.line)} ${item.label}`;
+    rows.push(
+      omitExcerpt || !item.excerpt ? row : `${row}\n  ${item.excerpt.replaceAll("\n", "\n  ")}`,
+    );
+  }
+  return rows;
+}
+
+function compactInspectInstruction(analysis: AnalysisDetails): string | undefined {
+  const inspect = analysis.items.find((item) => item.inspect !== undefined)?.inspect;
+  if (!inspect || typeof inspect.cursor !== "string") return undefined;
+  return `Inspect item #N: mode="inspect", cursor=${JSON.stringify(inspect.cursor)}, matchIndex=N${inspect.redact ? ", redact=true" : ""}.`;
+}
+
+function compactHeader(details: SignalGrepDetails, analysis: AnalysisDetails): string {
+  if (
+    analysis.termCounts &&
+    analysis.termCountsOffset !== undefined &&
+    analysis.totalTerms !== undefined
+  ) {
+    const start = analysis.termCountsOffset + 1;
+    const end = analysis.termCountsOffset + analysis.termCounts.length;
+    return `${analysis.kind} term inventory ${String(start)}–${String(end)} of ${String(analysis.totalTerms)} (${details.status}).`;
+  }
+  const first = analysis.items[0]?.index;
+  const last = analysis.items.at(-1)?.index;
+  const shown =
+    first === undefined || last === undefined
+      ? "showing none"
+      : `showing #${String(first)}–#${String(last)}`;
+  return `${analysis.kind}: ${String(analysis.totalItems)} retained ${analysis.unit} (${details.status}); ${shown}.`;
+}
+
+function distinctNextRequest(
+  details: SignalGrepDetails,
+  analysis: AnalysisDetails,
+): string | undefined {
+  if (!details.nextRequest) return undefined;
+  const serialized = JSON.stringify(details.nextRequest);
+  return serialized === JSON.stringify(analysis.termCountsNextRequest) ? undefined : serialized;
+}
+
+export function compactMcpModelText(result: SignalGrepResult): string {
+  const analysis = result.details.analysis;
+  if (!analysis) return result.text;
+  const header = compactHeader(result.details, analysis);
+  const inspect = compactInspectInstruction(analysis);
+  const nextRequest = distinctNextRequest(result.details, analysis);
+  const compact = [
+    header,
+    ...compactMetadata(result.details, analysis),
+    ...compactRows(analysis),
+    ...(inspect ? [inspect] : []),
+    ...(nextRequest ? [`Next request: ${nextRequest}`] : []),
+  ].join("\n");
+  const standard = result.text.replace(" Structured output retains per-item evidence details.", "");
+  return Buffer.byteLength(compact) < Buffer.byteLength(standard) ? compact : standard;
+}

--- a/src/mcp-output.ts
+++ b/src/mcp-output.ts
@@ -1,0 +1,9 @@
+export const DEFAULT_MCP_OUTPUT_MODE = "structured";
+
+export type SignalGrepMcpOutputMode = "structured" | "text" | "model";
+
+export function parseSignalGrepMcpOutputMode(value: string | undefined): SignalGrepMcpOutputMode {
+  if (value === undefined || value === DEFAULT_MCP_OUTPUT_MODE) return DEFAULT_MCP_OUTPUT_MODE;
+  if (value === "text" || value === "model") return value;
+  throw new Error('BAOER_SIGNAL_GREP_MCP_OUTPUT_MODE must be "structured", "text", or "model"');
+}

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -9,7 +9,7 @@ import { URL as URL2 } from "node:url";
 // package.json
 var package_default = {
   name: "baoer_signal_grep",
-  version: "1.2.3-6",
+  version: "1.2.3-7",
   description: "Context-efficient local search for files, documents, notes and logs across Pi, OMP and MCP clients",
   keywords: [
     "ai-agent",
@@ -159,6 +159,92 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+// src/mcp-output.ts
+var DEFAULT_MCP_OUTPUT_MODE = "structured";
+function parseSignalGrepMcpOutputMode(value) {
+  if (value === undefined || value === DEFAULT_MCP_OUTPUT_MODE)
+    return DEFAULT_MCP_OUTPUT_MODE;
+  if (value === "text" || value === "model")
+    return value;
+  throw new Error('BAOER_SIGNAL_GREP_MCP_OUTPUT_MODE must be "structured", "text", or "model"');
+}
+
+// src/mcp-model-output.ts
+function compactMetadata(details, analysis) {
+  return [
+    analysis.counts ? `Counts: ${JSON.stringify(analysis.counts)}` : undefined,
+    analysis.termCounts ? `Term counts: ${JSON.stringify(analysis.termCounts)}` : undefined,
+    analysis.termCountsNextRequest ? `More term counts: ${JSON.stringify(analysis.termCountsNextRequest)}` : undefined,
+    analysis.matchesRequest ? `Matches request: ${JSON.stringify(analysis.matchesRequest)}` : undefined,
+    analysis.changes ? `Changes: ${JSON.stringify(analysis.changes)}` : undefined,
+    analysis.scope ? `Scope: ${JSON.stringify(analysis.scope)}` : undefined,
+    analysis.chunks ? `Chunks: ${JSON.stringify(analysis.chunks)}` : undefined,
+    analysis.coverage ? `Coverage: ${JSON.stringify(analysis.coverage)}` : undefined,
+    analysis.stats ? `Stats: ${JSON.stringify(analysis.stats)}` : undefined,
+    analysis.kind === "outline" ? "[Outline signatures are deferred; inspect item #N for version-checked source.]" : undefined,
+    ...analysis.reasons.map((reason) => `[${reason}]`),
+    details.redactionApplied ? "[Display redaction applied.]" : undefined
+  ].filter((line) => line !== undefined);
+}
+function compactRows(analysis) {
+  const omitExcerpt = analysis.kind === "outline";
+  const rows = [];
+  let previousPath;
+  for (const item of analysis.items) {
+    if (item.path !== previousPath) {
+      rows.push(JSON.stringify(item.path));
+      previousPath = item.path;
+    }
+    const row = `#${String(item.index)} L${String(item.line)} ${item.label}`;
+    rows.push(omitExcerpt || !item.excerpt ? row : `${row}
+  ${item.excerpt.replaceAll(`
+`, `
+  `)}`);
+  }
+  return rows;
+}
+function compactInspectInstruction(analysis) {
+  const inspect = analysis.items.find((item) => item.inspect !== undefined)?.inspect;
+  if (!inspect || typeof inspect.cursor !== "string")
+    return;
+  return `Inspect item #N: mode="inspect", cursor=${JSON.stringify(inspect.cursor)}, matchIndex=N${inspect.redact ? ", redact=true" : ""}.`;
+}
+function compactHeader(details, analysis) {
+  if (analysis.termCounts && analysis.termCountsOffset !== undefined && analysis.totalTerms !== undefined) {
+    const start = analysis.termCountsOffset + 1;
+    const end = analysis.termCountsOffset + analysis.termCounts.length;
+    return `${analysis.kind} term inventory ${String(start)}–${String(end)} of ${String(analysis.totalTerms)} (${details.status}).`;
+  }
+  const first = analysis.items[0]?.index;
+  const last = analysis.items.at(-1)?.index;
+  const shown = first === undefined || last === undefined ? "showing none" : `showing #${String(first)}–#${String(last)}`;
+  return `${analysis.kind}: ${String(analysis.totalItems)} retained ${analysis.unit} (${details.status}); ${shown}.`;
+}
+function distinctNextRequest(details, analysis) {
+  if (!details.nextRequest)
+    return;
+  const serialized = JSON.stringify(details.nextRequest);
+  return serialized === JSON.stringify(analysis.termCountsNextRequest) ? undefined : serialized;
+}
+function compactMcpModelText(result) {
+  const analysis = result.details.analysis;
+  if (!analysis)
+    return result.text;
+  const header = compactHeader(result.details, analysis);
+  const inspect = compactInspectInstruction(analysis);
+  const nextRequest = distinctNextRequest(result.details, analysis);
+  const compact = [
+    header,
+    ...compactMetadata(result.details, analysis),
+    ...compactRows(analysis),
+    ...inspect ? [inspect] : [],
+    ...nextRequest ? [`Next request: ${nextRequest}`] : []
+  ].join(`
+`);
+  const standard = result.text.replace(" Structured output retains per-item evidence details.", "");
+  return Buffer.byteLength(compact) < Buffer.byteLength(standard) ? compact : standard;
+}
 
 // src/rg.ts
 import { isAbsolute as isAbsolute3, relative as relative2, resolve as resolve4 } from "node:path";
@@ -4795,6 +4881,7 @@ function analysisTermPage(result, id, offset) {
         termCountsOffset: offset,
         totalTerms: all.length,
         ...nextRequest ? { termCountsNextRequest: nextRequest } : {},
+        matchesRequest,
         ...result.coverage ? { coverage: result.coverage } : {}
       }
     }
@@ -10098,7 +10185,7 @@ Next request: ${JSON.stringify({ cursor, ...selectedPaths ? { paths: selectedPat
 }
 
 // src/prompt-guidelines.ts
-function signalGrepPromptGuidelines() {
+function signalGrepPromptGuidelines(structuredOutput = true) {
   return [
     `Use baoer_signal_grep for content search. Start with pattern and optional path; omit mode and limit to let auto choose a complete small result or a broad summary. Use literal=true for literal code fragments rather than escaping them as regex.`,
     `An omitted path searches the project cwd. Use scope:"strict" for a question restricted to one path; otherwise, if an explicit subpath has zero matches, ordinary and content-analysis searches retry from cwd and return project-wide matches with an expansion notice. Explicit absolute paths and .. traversal can search outside cwd, except protected external system areas and .git internals. Git changes mode remains cwd-scoped.`,
@@ -10116,14 +10203,15 @@ function signalGrepPromptGuidelines() {
     `Use mode:"structure" plus an ast-grep pattern such as "compare($X, $X)" or "send()" for code shapes across whitespace; no literal/regex or scope options. Use path/glob/exclude to narrow admitted syntax.`,
     `Use mode:"concept" plus a natural-language query when names are unknown. It runs a pinned local multilingual model only after explicit installation; no search downloads weights or sends code to a remote model. Similarity scores identify source candidates, not proof. File/concept/structure discovery never expands its requested path.`,
     `If inspection reports missing source, execute its complete nextRequest with sourceCursor. Never treat a partial source excerpt as the complete implementation.`,
-    `When status=partial, read details.analysis.coverage to see which conclusion is incomplete; an exact occurrence count may remain complete even when syntax or related-test analysis is partial.`
+    structuredOutput ? `When status=partial, read details.analysis.coverage to see which conclusion is incomplete; an exact occurrence count may remain complete even when syntax or related-test analysis is partial.` : `When status=partial, read the visible Coverage and bracketed reasons to see which conclusion is incomplete; an exact occurrence count may remain complete even when syntax or related-test analysis is partial.`
   ];
 }
-function signalGrepMcpInstructions() {
+function signalGrepMcpInstructions(outputMode = DEFAULT_MCP_OUTPUT_MODE) {
+  const outputInstruction = outputMode === "structured" ? "Successful MCP results provide text (the complete formatted evidence page) and details (counts, coverage and continuation selectors). The text content block contains the same page. Use either representation; do not treat the two copies as separate evidence." : outputMode === "model" ? "Successful MCP results provide one model-facing text page. Compact analysis rows share their path and inspect cursor; use the numbered item with the visible inspect template, and copy continuation requests exactly." : "Successful MCP results provide one complete formatted text page, including counts, coverage and continuation selectors.";
   return [
     "Use baoer_signal_grep for read-only local filesystem search and bounded source inspection. The server searches from its configured project working directory. Prefer it over unbounded text search when gathering project evidence.",
-    "Successful MCP results provide text (the complete formatted evidence page) and details (counts, coverage and continuation selectors). The text content block contains the same page. Use either representation; do not treat the two copies as separate evidence.",
-    ...signalGrepPromptGuidelines()
+    outputInstruction,
+    ...signalGrepPromptGuidelines(outputMode === "structured")
   ].join(`
 `);
 }
@@ -10314,30 +10402,35 @@ var DEFAULT_MCP_MAX_SESSIONS = 100;
 var DEFAULT_MCP_SESSION_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
 var MAX_MCP_BODY_BYTES = 16 * 1024 * 1024;
 var BAOER_SIGNAL_GREP_MCP_VERSION = package_default.version;
-var SIGNAL_GREP_TOOL = {
-  name: "baoer_signal_grep",
-  title: "baoer_signal_grep",
-  description: SIGNAL_GREP_DESCRIPTION,
-  inputSchema: signalGrepSchema,
-  outputSchema: {
-    type: "object",
-    properties: {
-      text: {
-        type: "string",
-        description: "Complete formatted result page, including source evidence, limits and continuation requests."
-      },
-      details: { type: "object" }
+var SIGNAL_GREP_OUTPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    text: {
+      type: "string",
+      description: "Complete formatted result page, including source evidence, limits and continuation requests."
     },
-    required: ["text", "details"]
+    details: { type: "object" }
   },
-  annotations: {
-    title: "baoer_signal_grep",
-    readOnlyHint: true,
-    destructiveHint: false,
-    idempotentHint: true,
-    openWorldHint: false
-  }
+  required: ["text", "details"]
 };
+function signalGrepTool(outputMode) {
+  const tool = {
+    name: "baoer_signal_grep",
+    title: "baoer_signal_grep",
+    description: SIGNAL_GREP_DESCRIPTION,
+    inputSchema: signalGrepSchema,
+    annotations: {
+      title: "baoer_signal_grep",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false
+    }
+  };
+  if (outputMode === "structured")
+    tool.outputSchema = SIGNAL_GREP_OUTPUT_SCHEMA;
+  return tool;
+}
 function createDefaultSignalGrepMcpService() {
   return new SignalGrepService({
     runRipgrep: createRipgrepRunner(),
@@ -10367,25 +10460,28 @@ function toolError(error) {
     isError: true
   };
 }
-function createSignalGrepMcpServer(service, cwd) {
+function createSignalGrepMcpServer(service, cwd, outputMode = DEFAULT_MCP_OUTPUT_MODE) {
+  const resolvedOutputMode = parseSignalGrepMcpOutputMode(outputMode);
+  const tool = signalGrepTool(resolvedOutputMode);
   const server = new McpServer({ name: "baoer_signal_grep", version: BAOER_SIGNAL_GREP_MCP_VERSION }, {
     capabilities: { tools: {} },
-    instructions: signalGrepMcpInstructions()
+    instructions: signalGrepMcpInstructions(resolvedOutputMode)
   });
   server.server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: [SIGNAL_GREP_TOOL]
+    tools: [tool]
   }));
   server.server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
-    if (request.params.name !== SIGNAL_GREP_TOOL.name) {
+    if (request.params.name !== tool.name) {
       return toolError(new Error(`Unknown tool: ${request.params.name}`));
     }
     try {
       const input = parseSignalGrepInput(request.params.arguments ?? {});
       const result = await service.search(input, cwd, extra.signal);
-      return {
-        content: [{ type: "text", text: result.text }],
-        structuredContent: { text: result.text, details: result.details }
-      };
+      const text = resolvedOutputMode === "model" ? compactMcpModelText(result) : result.text;
+      const content = [{ type: "text", text }];
+      if (resolvedOutputMode !== "structured")
+        return { content };
+      return { content, structuredContent: { text: result.text, details: result.details } };
     } catch (error) {
       return toolError(error);
     }
@@ -10578,7 +10674,7 @@ async function handleMcpRequest(request, response, state, createService, cwd) {
             }
           }
         });
-        const protocol = createSignalGrepMcpServer(service, cwd);
+        const protocol = createSignalGrepMcpServer(service, cwd, state.outputMode);
         pendingSession = {
           protocol,
           service,
@@ -10667,6 +10763,7 @@ async function startSignalGrepMcpServer(options = {}) {
     maxSessions,
     idleTimeoutMs,
     allowedOrigins: new Set(options.allowedOrigins ?? []),
+    outputMode: parseSignalGrepMcpOutputMode(options.outputMode),
     cleanupErrors: [],
     pendingInitializations: 0,
     closing: false
@@ -10763,8 +10860,9 @@ async function startSignalGrepMcpStdioServer(options = {}) {
   const cwd = options.cwd ?? process.cwd();
   const input = options.input ?? process.stdin;
   const output = options.output ?? process.stdout;
+  const outputMode = parseSignalGrepMcpOutputMode(options.outputMode ?? DEFAULT_MCP_OUTPUT_MODE);
   const service = (options.createService ?? createDefaultSignalGrepMcpService)();
-  const protocol = createSignalGrepMcpServer(service, cwd);
+  const protocol = createSignalGrepMcpServer(service, cwd, outputMode);
   const lifecycle = Promise.withResolvers();
   let closePromise;
   let transportFailure;
@@ -10841,14 +10939,15 @@ function environmentInteger(name, fallback, minimum, maximum) {
 function allowedOrigins() {
   return (process.env.BAOER_SIGNAL_GREP_MCP_ALLOWED_ORIGINS ?? "").split(",").map((origin) => origin.trim()).filter((origin) => origin.length > 0);
 }
-async function runHttpServer() {
+async function runHttpServer(outputMode) {
   const running = await startSignalGrepMcpServer({
     cwd: process.env.BAOER_SIGNAL_GREP_MCP_CWD ?? process.cwd(),
     host: process.env.BAOER_SIGNAL_GREP_MCP_HOST ?? DEFAULT_MCP_HOST,
     port: environmentInteger("BAOER_SIGNAL_GREP_MCP_PORT", DEFAULT_MCP_PORT, 0, 65535),
     maxSessions: environmentInteger("BAOER_SIGNAL_GREP_MCP_MAX_SESSIONS", DEFAULT_MCP_MAX_SESSIONS, 1, Number.MAX_SAFE_INTEGER),
     sessionIdleTimeoutMs: environmentInteger("BAOER_SIGNAL_GREP_MCP_SESSION_IDLE_MS", DEFAULT_MCP_SESSION_IDLE_TIMEOUT_MS, 1, Number.MAX_SAFE_INTEGER),
-    allowedOrigins: allowedOrigins()
+    allowedOrigins: allowedOrigins(),
+    outputMode
   });
   const address = running.httpServer.address();
   if (!address || !(address instanceof Object)) {
@@ -10878,9 +10977,10 @@ async function runHttpServer() {
   process.once("SIGINT", shutdown);
   process.once("SIGTERM", shutdown);
 }
-async function runStdioServer() {
+async function runStdioServer(outputMode) {
   const running = await startSignalGrepMcpStdioServer({
-    cwd: process.env.BAOER_SIGNAL_GREP_MCP_CWD ?? process.env.CLAUDE_PROJECT_DIR ?? process.cwd()
+    cwd: process.env.BAOER_SIGNAL_GREP_MCP_CWD ?? process.env.CLAUDE_PROJECT_DIR ?? process.cwd(),
+    outputMode
   });
   process.stderr.write(`baoer_signal_grep MCP serving one local client over stdio
 `);
@@ -10908,11 +11008,12 @@ async function main() {
     process.stdout.write(BAOER_SIGNAL_GREP_MCP_USAGE);
     return;
   }
+  const outputMode = parseSignalGrepMcpOutputMode(process.env.BAOER_SIGNAL_GREP_MCP_OUTPUT_MODE);
   if (transport === "stdio") {
-    await runStdioServer();
+    await runStdioServer(outputMode);
     return;
   }
-  await runHttpServer();
+  await runHttpServer(outputMode);
 }
 try {
   await main();

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -8,6 +8,7 @@ import {
   startSignalGrepMcpServer,
 } from "./mcp.js";
 import { parseSignalGrepMcpTransport, BAOER_SIGNAL_GREP_MCP_USAGE } from "./mcp-cli.js";
+import { parseSignalGrepMcpOutputMode, type SignalGrepMcpOutputMode } from "./mcp-output.js";
 import { startSignalGrepMcpStdioServer } from "./mcp-stdio.js";
 
 function environmentInteger(
@@ -34,7 +35,7 @@ function allowedOrigins(): string[] {
     .filter((origin) => origin.length > 0);
 }
 
-async function runHttpServer(): Promise<void> {
+async function runHttpServer(outputMode: SignalGrepMcpOutputMode): Promise<void> {
   const running = await startSignalGrepMcpServer({
     cwd: process.env.BAOER_SIGNAL_GREP_MCP_CWD ?? process.cwd(),
     host: process.env.BAOER_SIGNAL_GREP_MCP_HOST ?? DEFAULT_MCP_HOST,
@@ -52,6 +53,7 @@ async function runHttpServer(): Promise<void> {
       Number.MAX_SAFE_INTEGER,
     ),
     allowedOrigins: allowedOrigins(),
+    outputMode,
   });
 
   const address = running.httpServer.address();
@@ -82,9 +84,10 @@ async function runHttpServer(): Promise<void> {
   process.once("SIGTERM", shutdown);
 }
 
-async function runStdioServer(): Promise<void> {
+async function runStdioServer(outputMode: SignalGrepMcpOutputMode): Promise<void> {
   const running = await startSignalGrepMcpStdioServer({
     cwd: process.env.BAOER_SIGNAL_GREP_MCP_CWD ?? process.env.CLAUDE_PROJECT_DIR ?? process.cwd(),
+    outputMode,
   });
   process.stderr.write("baoer_signal_grep MCP serving one local client over stdio\n");
   process.stderr.write(`baoer_signal_grep MCP working directory: ${running.cwd}\n`);
@@ -111,11 +114,12 @@ async function main(): Promise<void> {
     process.stdout.write(BAOER_SIGNAL_GREP_MCP_USAGE);
     return;
   }
+  const outputMode = parseSignalGrepMcpOutputMode(process.env.BAOER_SIGNAL_GREP_MCP_OUTPUT_MODE);
   if (transport === "stdio") {
-    await runStdioServer();
+    await runStdioServer(outputMode);
     return;
   }
-  await runHttpServer();
+  await runHttpServer(outputMode);
 }
 
 try {

--- a/src/mcp-stdio.ts
+++ b/src/mcp-stdio.ts
@@ -5,11 +5,17 @@ import {
   createSignalGrepMcpServer,
   type SignalGrepMcpService,
 } from "./mcp.js";
+import {
+  DEFAULT_MCP_OUTPUT_MODE,
+  parseSignalGrepMcpOutputMode,
+  type SignalGrepMcpOutputMode,
+} from "./mcp-output.js";
 
 export interface SignalGrepMcpStdioOptions {
   cwd?: string;
   input?: Readable;
   output?: Writable;
+  outputMode?: SignalGrepMcpOutputMode;
   createService?: () => SignalGrepMcpService;
 }
 
@@ -29,8 +35,9 @@ export async function startSignalGrepMcpStdioServer(
   const cwd = options.cwd ?? process.cwd();
   const input = options.input ?? process.stdin;
   const output = options.output ?? process.stdout;
+  const outputMode = parseSignalGrepMcpOutputMode(options.outputMode ?? DEFAULT_MCP_OUTPUT_MODE);
   const service = (options.createService ?? createDefaultSignalGrepMcpService)();
-  const protocol = createSignalGrepMcpServer(service, cwd);
+  const protocol = createSignalGrepMcpServer(service, cwd, outputMode);
 
   const lifecycle = Promise.withResolvers<void>();
   let closePromise: Promise<void> | undefined;

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -13,6 +13,12 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { SignalGrepResult } from "./types.js";
+import {
+  DEFAULT_MCP_OUTPUT_MODE,
+  parseSignalGrepMcpOutputMode,
+  type SignalGrepMcpOutputMode,
+} from "./mcp-output.js";
+import { compactMcpModelText } from "./mcp-model-output.js";
 import { createRipgrepRunner } from "./rg.js";
 import { createCtagsStructureProvider } from "./structure.js";
 import { SignalGrepService, type SignalGrepInput } from "./service.js";
@@ -28,34 +34,39 @@ export const MAX_MCP_BODY_BYTES = 16 * 1024 * 1024;
 
 const BAOER_SIGNAL_GREP_MCP_VERSION = packageMetadata.version;
 
-const SIGNAL_GREP_TOOL: Tool = {
-  name: "baoer_signal_grep",
-  title: "baoer_signal_grep",
-  description: SIGNAL_GREP_DESCRIPTION,
-  // TypeBox and MCP both consume JSON Schema, but their TypeScript declarations are intentionally unrelated.
-  // SAFETY: signalGrepSchema is runtime-validated TypeBox JSON Schema and matches MCP's input schema shape.
-  // oxlint-disable-next-line no-unsafe-type-assertion -- this is the checked JSON Schema adapter boundary
-  inputSchema: signalGrepSchema as unknown as Tool["inputSchema"],
-  outputSchema: {
-    type: "object",
-    properties: {
-      text: {
-        type: "string",
-        description:
-          "Complete formatted result page, including source evidence, limits and continuation requests.",
-      },
-      details: { type: "object" },
+const SIGNAL_GREP_OUTPUT_SCHEMA: Tool["outputSchema"] = {
+  type: "object",
+  properties: {
+    text: {
+      type: "string",
+      description:
+        "Complete formatted result page, including source evidence, limits and continuation requests.",
     },
-    required: ["text", "details"],
+    details: { type: "object" },
   },
-  annotations: {
-    title: "baoer_signal_grep",
-    readOnlyHint: true,
-    destructiveHint: false,
-    idempotentHint: true,
-    openWorldHint: false,
-  },
+  required: ["text", "details"],
 };
+
+function signalGrepTool(outputMode: SignalGrepMcpOutputMode): Tool {
+  const tool: Tool = {
+    name: "baoer_signal_grep",
+    title: "baoer_signal_grep",
+    description: SIGNAL_GREP_DESCRIPTION,
+    // TypeBox and MCP both consume JSON Schema, but their TypeScript declarations are intentionally unrelated.
+    // SAFETY: signalGrepSchema is runtime-validated TypeBox JSON Schema and matches MCP's input schema shape.
+    // oxlint-disable-next-line no-unsafe-type-assertion -- this is the checked JSON Schema adapter boundary
+    inputSchema: signalGrepSchema as unknown as Tool["inputSchema"],
+    annotations: {
+      title: "baoer_signal_grep",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  };
+  if (outputMode === "structured") tool.outputSchema = SIGNAL_GREP_OUTPUT_SCHEMA;
+  return tool;
+}
 
 export interface SignalGrepMcpService {
   search(input: SignalGrepInput, cwd: string, signal?: AbortSignal): Promise<SignalGrepResult>;
@@ -95,32 +106,38 @@ function toolError(error: unknown) {
   };
 }
 
-export function createSignalGrepMcpServer(service: SignalGrepMcpService, cwd: string): McpServer {
+export function createSignalGrepMcpServer(
+  service: SignalGrepMcpService,
+  cwd: string,
+  outputMode: SignalGrepMcpOutputMode = DEFAULT_MCP_OUTPUT_MODE,
+): McpServer {
+  const resolvedOutputMode = parseSignalGrepMcpOutputMode(outputMode);
+  const tool = signalGrepTool(resolvedOutputMode);
   const server = new McpServer(
     { name: "baoer_signal_grep", version: BAOER_SIGNAL_GREP_MCP_VERSION },
     {
       capabilities: { tools: {} },
-      instructions: signalGrepMcpInstructions(),
+      instructions: signalGrepMcpInstructions(resolvedOutputMode),
     },
   );
 
   server.server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: [SIGNAL_GREP_TOOL],
+    tools: [tool],
   }));
 
   server.server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
-    if (request.params.name !== SIGNAL_GREP_TOOL.name) {
+    if (request.params.name !== tool.name) {
       return toolError(new Error(`Unknown tool: ${request.params.name}`));
     }
     try {
       const input = parseSignalGrepInput(request.params.arguments ?? {});
       const result = await service.search(input, cwd, extra.signal);
-      return {
-        content: [{ type: "text" as const, text: result.text }],
-        // Clients may expose only structuredContent to their model. Both representations
-        // must use the same final page, after service-level formatting and redaction.
-        structuredContent: { text: result.text, details: result.details },
-      };
+      const text = resolvedOutputMode === "model" ? compactMcpModelText(result) : result.text;
+      const content = [{ type: "text" as const, text }];
+      if (resolvedOutputMode !== "structured") return { content };
+      // Clients may expose only structuredContent to their model. Both representations
+      // must use the same final page, after service-level formatting and redaction.
+      return { content, structuredContent: { text: result.text, details: result.details } };
     } catch (error) {
       return toolError(error);
     }
@@ -162,6 +179,7 @@ interface McpSessionState {
   readonly maxSessions: number;
   readonly idleTimeoutMs: number;
   readonly allowedOrigins: ReadonlySet<string>;
+  readonly outputMode: SignalGrepMcpOutputMode;
   readonly cleanupErrors: unknown[];
   pendingInitializations: number;
   closing: boolean;
@@ -206,6 +224,7 @@ export interface SignalGrepMcpHttpOptions {
   allowedOrigins?: readonly string[];
   maxSessions?: number;
   sessionIdleTimeoutMs?: number;
+  outputMode?: SignalGrepMcpOutputMode;
   createService?: () => SignalGrepMcpService;
 }
 
@@ -384,7 +403,7 @@ async function handleMcpRequest(
             }
           },
         });
-        const protocol = createSignalGrepMcpServer(service, cwd);
+        const protocol = createSignalGrepMcpServer(service, cwd, state.outputMode);
         pendingSession = {
           protocol,
           service,
@@ -486,6 +505,7 @@ export async function startSignalGrepMcpServer(
     maxSessions,
     idleTimeoutMs,
     allowedOrigins: new Set(options.allowedOrigins ?? []),
+    outputMode: parseSignalGrepMcpOutputMode(options.outputMode),
     cleanupErrors: [],
     pendingInitializations: 0,
     closing: false,

--- a/src/prompt-guidelines.ts
+++ b/src/prompt-guidelines.ts
@@ -1,6 +1,7 @@
 import { MAX_INSPECT_TARGETS } from "./types.js";
+import { DEFAULT_MCP_OUTPUT_MODE, type SignalGrepMcpOutputMode } from "./mcp-output.js";
 
-export function signalGrepPromptGuidelines(): string[] {
+export function signalGrepPromptGuidelines(structuredOutput = true): string[] {
   return [
     `Use baoer_signal_grep for content search. Start with pattern and optional path; omit mode and limit to let auto choose a complete small result or a broad summary. Use literal=true for literal code fragments rather than escaping them as regex.`,
     `An omitted path searches the project cwd. Use scope:"strict" for a question restricted to one path; otherwise, if an explicit subpath has zero matches, ordinary and content-analysis searches retry from cwd and return project-wide matches with an expansion notice. Explicit absolute paths and .. traversal can search outside cwd, except protected external system areas and .git internals. Git changes mode remains cwd-scoped.`,
@@ -18,14 +19,24 @@ export function signalGrepPromptGuidelines(): string[] {
     `Use mode:"structure" plus an ast-grep pattern such as "compare($X, $X)" or "send()" for code shapes across whitespace; no literal/regex or scope options. Use path/glob/exclude to narrow admitted syntax.`,
     `Use mode:"concept" plus a natural-language query when names are unknown. It runs a pinned local multilingual model only after explicit installation; no search downloads weights or sends code to a remote model. Similarity scores identify source candidates, not proof. File/concept/structure discovery never expands its requested path.`,
     `If inspection reports missing source, execute its complete nextRequest with sourceCursor. Never treat a partial source excerpt as the complete implementation.`,
-    `When status=partial, read details.analysis.coverage to see which conclusion is incomplete; an exact occurrence count may remain complete even when syntax or related-test analysis is partial.`,
+    structuredOutput
+      ? `When status=partial, read details.analysis.coverage to see which conclusion is incomplete; an exact occurrence count may remain complete even when syntax or related-test analysis is partial.`
+      : `When status=partial, read the visible Coverage and bracketed reasons to see which conclusion is incomplete; an exact occurrence count may remain complete even when syntax or related-test analysis is partial.`,
   ];
 }
 
-export function signalGrepMcpInstructions(): string {
+export function signalGrepMcpInstructions(
+  outputMode: SignalGrepMcpOutputMode = DEFAULT_MCP_OUTPUT_MODE,
+): string {
+  const outputInstruction =
+    outputMode === "structured"
+      ? "Successful MCP results provide text (the complete formatted evidence page) and details (counts, coverage and continuation selectors). The text content block contains the same page. Use either representation; do not treat the two copies as separate evidence."
+      : outputMode === "model"
+        ? "Successful MCP results provide one model-facing text page. Compact analysis rows share their path and inspect cursor; use the numbered item with the visible inspect template, and copy continuation requests exactly."
+        : "Successful MCP results provide one complete formatted text page, including counts, coverage and continuation selectors.";
   return [
     "Use baoer_signal_grep for read-only local filesystem search and bounded source inspection. The server searches from its configured project working directory. Prefer it over unbounded text search when gathering project evidence.",
-    "Successful MCP results provide text (the complete formatted evidence page) and details (counts, coverage and continuation selectors). The text content block contains the same page. Use either representation; do not treat the two copies as separate evidence.",
-    ...signalGrepPromptGuidelines(),
+    outputInstruction,
+    ...signalGrepPromptGuidelines(outputMode === "structured"),
   ].join("\n");
 }


### PR DESCRIPTION
## Change

- Add strict `structured`, `text`, and `model` MCP output modes through `BAOER_SIGNAL_GREP_MCP_OUTPUT_MODE`.
- Keep the existing structured response as the compatible default. Text mode keeps the standard page exactly and omits `structuredContent`; model mode emits one model-facing text page and selects the smaller of the standard page and a compact analysis view.
- Preserve retained item identities, counts, scope, coverage, partial reasons, redaction state, inspection selectors, item pagination, term-count pagination, and the independent transition from term inventory to match evidence.
- Configure the bundled Claude Code, Codex, and Kimi plugins to use model mode.
- Build the release artifacts and bump the package/plugin version to `1.2.3-7`.

Closes #53

## Validation

- [x] `bun run check:local` (357 passed, 1 pre-existing optional offline-model test skipped, 0 failed)
- [x] `bun run pack:check`
- [x] Reviewed the final diff and shipped artifacts

Additional verification:

- `bun run test:mcp-hosts`: Claude Code 2.1.261, Codex CLI 0.153.4, and Kimi Code 0.41.0 all consumed the real stdio MCP output through controlled model endpoints.
- Each host retained all 80 large fixture matches across two cursor pages with no omission or duplication, preserved inspect navigation, and surfaced invalid-input failures.
- The real 66-symbol Python outline first page was 1,558 model-visible bytes in model mode versus the 29,429-character issue reproduction, a 94.7% reduction.
- Node smoke tests exercised HTTP and stdio transports in all three output modes and verified invalid configuration fails before transport startup.
- `git diff --check` passed.

## Compatibility and risks

The default remains `structured`, so direct MCP connections and programmatic clients retain the current output schema and `structuredContent`. Only bundled native host manifests opt into `model`. Invalid mode values fail explicitly at startup. Model mode may defer outline signature excerpts to version-checked `inspect` calls; the item indices, shared inspect selector, coverage, and continuations remain visible. The optional real Concept retrieval test stayed skipped because its local model assets are not installed; the explicit missing-assets test passed.

## Documentation

- [x] Updated user-facing documentation where needed
- [x] No private source, tests, internal documents, credentials or logs are included

README and changelog now document mode selection, compatibility, failure behavior, and the outline inspection tradeoff.

## AI assistance

Codex using the GPT-5 family authored and reviewed the change and ran all validation listed above. No separate human review has been recorded yet.