### PR TITLE
feat: add precise search enforcement modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.4.0] - 2026-09-09
+
+- Identify the exact Bash or PowerShell subcommand that triggered strict native search enforcement, including its sequence and bounded source position, while preserving the existing allow/deny policy. Denials now explain that the host call is atomic and instruct agents to split non-search work before routing only the search through `baoer_signal_grep`.
+- Add explicit `"hard"`, `"prefer"`, and `"off"` search-enforcement modes while retaining `true` and `false` configuration compatibility. Hard enforcement remains the default; prefer mode keeps the dedicated tool and model guidance without denying conventional searches.
+- Let Claude Code, Codex and Kimi native hooks select enforcement through `BAOER_SIGNAL_GREP_ENFORCE_SEARCH=hard|prefer|off`. Missing configuration remains hard, and unsupported values fail closed with a visible configuration error.
+- Document why output-only pipeline filters remain available while direct content searches and pipelines containing another search producer remain blocked.
+
 ## [1.3.2] - 2026-09-09
 
 - Reduce the native model-host MCP description and workflow instructions while preserving ordinary search, strict scope, completeness, cursor and inspection recovery guidance. Structured and text consumers retain the full compatibility instructions.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To use your own ripgrep, set `BAOER_SIGNAL_GREP_RG_PATH` in the MCP server or Pi
 pi install npm:baoer_signal_grep
 ```
 
-Restart Pi after installing or updating. Pi uses this plugin for conventional searches by default; reads, edits, tests, builds and scripts remain available. To turn enforcement off, set `"enforceSearch": false` in `~/.pi/agent/baoer_signal_grep.json` and restart. Set `"locale": "zh-CN"` there for the Chinese interface.
+Restart Pi after installing or updating. Pi uses this plugin for conventional searches by default; reads, edits, tests, builds and scripts remain available. `enforceSearch` accepts `"hard"` (the default), `"prefer"` (keep the dedicated tool and guidance without denying alternative searches), or `"off"`. Existing `true` and `false` values remain aliases for `"hard"` and `"off"`. Configure it in `~/.pi/agent/baoer_signal_grep.json`, then restart. Set `"locale": "zh-CN"` there for the Chinese interface.
 
 ### OMP (Oh My Pi)
 
@@ -84,7 +84,7 @@ Restart Pi after installing or updating. Pi uses this plugin for conventional se
 omp install npm:baoer_signal_grep@latest
 ```
 
-Restart OMP after installing or updating. The package declares its native OMP extension, which registers `baoer_signal_grep`, removes OMP's built-in `grep` and `glob` entries from the active tool set, and blocks direct search commands while leaving reads, edits, tests, builds and other development tools available. OMP's active profile is respected; the default configuration file is `~/.omp/agent/baoer_signal_grep.json`, and a named profile uses `~/.omp/profiles/<profile>/agent/baoer_signal_grep.json`. Set `"enforceSearch": false` in the active file to disable OMP enforcement, then restart OMP. Set `"locale": "zh-CN"` to use the Chinese interface.
+Restart OMP after installing or updating. The package declares its native OMP extension and registers `baoer_signal_grep`. In the default hard mode it removes OMP's built-in `grep` and `glob` entries from the active tool set and blocks direct search commands while leaving reads, edits, tests, builds and other development tools available. Prefer mode keeps both the dedicated and alternative tools active, adds model guidance, and does not deny shell searches. OMP's active profile is respected; the default configuration file is `~/.omp/agent/baoer_signal_grep.json`, and a named profile uses `~/.omp/profiles/<profile>/agent/baoer_signal_grep.json`. Set `enforceSearch` to `"hard"` (default), `"prefer"`, or `"off"` in the active file, then restart OMP. Existing `true` and `false` values remain compatible. Set `"locale": "zh-CN"` to use the Chinese interface.
 
 ### Claude Code or Codex: MCP connection
 
@@ -112,7 +112,9 @@ For conventional search enforcement in other hosts:
 
 Kimi Code's web mode can start plugin MCP servers from its installation directory. If relative MCP searches resolve to the wrong project, keep the native plugin for search enforcement and add a project-local `.kimi-code/mcp.json` entry with the same `baoer_signal_grep` server and an explicit absolute `cwd` for that project.
 
-Restart after installation. To disable, use Claude Code `/plugin`, Codex `/hooks`, or Kimi `/plugins disable baoer-signal-grep` followed by `/reload`.
+Restart after installation. Native hooks use hard enforcement by default. To keep the native plugin, MCP tool and model guidance without denying conventional searches, start the host with `BAOER_SIGNAL_GREP_ENFORCE_SEARCH=prefer`; use `off` to disable only hook enforcement. Accepted values are `hard`, `prefer`, and `off`; an unsupported value fails closed instead of silently allowing a search. The setting is inherited from the host process, so a project cannot lower a user's policy merely by committing a repository configuration file. You can still disable the complete integration through Claude Code `/plugin`, Codex `/hooks`, or Kimi `/plugins disable baoer-signal-grep` followed by `/reload`.
+
+In hard mode, a direct search such as `grep warning report.txt` is denied. A trailing filter such as `cat report.txt | grep warning` remains available because it filters output from a non-search producer; `find src | grep test` and `rg warning src | grep result` remain denied because their pipelines already contain a direct search producer. If one subcommand in a compound shell call is denied, the host executes none of that call. The denial identifies the detected search and tells the agent to retry non-search operations separately.
 
 Local searches stay on your machine. Only grant access to files your agent is allowed to read. HTTP deployments need an authenticated gateway before public exposure; see [Security](SECURITY.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,7 +76,7 @@ MCP 需要 Node.js 22.19+；Pi 需要 Pi 0.84.3+，以及 Node.js 22.19+ 或 Bun
 pi install npm:baoer_signal_grep
 ```
 
-安装或更新后重启 Pi。Pi 默认让常规搜索使用本插件，读取、编辑、测试、构建和脚本仍可使用。如需关闭强制搜索，在 `~/.pi/agent/baoer_signal_grep.json` 中设置 `"enforceSearch": false` 后重启；设置 `"locale": "zh-CN"` 可启用中文界面。
+安装或更新后重启 Pi。Pi 默认让常规搜索使用本插件，读取、编辑、测试、构建和脚本仍可使用。`enforceSearch` 支持 `"hard"`（默认严格拦截）、`"prefer"`（保留专用工具和模型指引，但不拒绝其他搜索）和 `"off"`；已有的 `true`、`false` 分别继续等价于 `"hard"`、`"off"`。请在 `~/.pi/agent/baoer_signal_grep.json` 中配置后重启；设置 `"locale": "zh-CN"` 可启用中文界面。
 
 ### OMP（Oh My Pi）
 
@@ -84,7 +84,7 @@ pi install npm:baoer_signal_grep
 omp install npm:baoer_signal_grep@latest
 ```
 
-安装或更新后重启 OMP。安装包声明了 OMP 原生扩展：注册 `baoer_signal_grep`，从活动工具集中移除 OMP 内置的 `grep` 和 `glob`，并在执行前阻止直接搜索命令；读取、编辑、测试、构建和其他开发工具仍可使用。OMP 当前 profile 会被正确识别：默认配置文件是 `~/.omp/agent/baoer_signal_grep.json`，命名 profile 使用 `~/.omp/profiles/<profile>/agent/baoer_signal_grep.json`。如需关闭 OMP 的强制搜索，在当前配置文件中设置 `"enforceSearch": false` 后重启 OMP；设置 `"locale": "zh-CN"` 可启用中文界面。
+安装或更新后重启 OMP。安装包声明了 OMP 原生扩展并注册 `baoer_signal_grep`。默认 hard 模式会从活动工具集中移除 OMP 内置的 `grep` 和 `glob`，并在执行前阻止直接搜索命令，同时保留读取、编辑、测试、构建和其他开发工具。prefer 模式会同时保留专用工具与其他搜索工具，加入模型指引，但不拒绝 shell 搜索。OMP 当前 profile 会被正确识别：默认配置文件是 `~/.omp/agent/baoer_signal_grep.json`，命名 profile 使用 `~/.omp/profiles/<profile>/agent/baoer_signal_grep.json`。在当前文件中将 `enforceSearch` 设置为 `"hard"`（默认）、`"prefer"` 或 `"off"` 后重启 OMP；已有的 `true`、`false` 继续兼容。设置 `"locale": "zh-CN"` 可启用中文界面。
 
 ### Claude Code 或 Codex：连接 MCP
 
@@ -112,7 +112,9 @@ MCP 默认同时返回可读文本和结构化证据。如果宿主会把两种�
 
 Kimi Code 的 web 模式可能从安装目录启动插件 MCP 服务。如果相对路径搜索解析到了错误项目，请继续使用原生插件强制搜索，并在项目内的 `.kimi-code/mcp.json` 中配置同名 `baoer_signal_grep` 服务，显式填写该项目的绝对 `cwd`。
 
-安装后重启。关闭方式：Claude Code 使用 `/plugin`，Codex 使用 `/hooks`，Kimi 使用 `/plugins disable baoer-signal-grep` 后执行 `/reload`。
+安装后重启。原生钩子默认使用严格模式。如需保留原生插件、MCP 工具和模型指引，但不硬性拒绝其他搜索，请使用 `BAOER_SIGNAL_GREP_ENFORCE_SEARCH=prefer` 启动宿主；设置为 `off` 只关闭钩子强制策略。可用值为 `hard`、`prefer` 和 `off`，非法值会安全拒绝并明确报错，不会静默放行。该设置由宿主进程继承，因此项目不能仅靠提交仓库配置文件降低用户的全局策略。仍可通过 Claude Code `/plugin`、Codex `/hooks`，或 Kimi `/plugins disable baoer-signal-grep` 后执行 `/reload` 来关闭整个集成。
+
+严格模式下，`grep warning report.txt` 这类直接搜索会被拒绝；`cat report.txt | grep warning` 仍可用，因为它只是过滤一个非搜索命令的输出。`find src | grep test` 和 `rg warning src | grep result` 仍会被拒绝，因为管道中已经包含直接搜索来源。复合 shell 调用中只要一个子命令被拒绝，宿主就不会执行其中任何操作；拒绝信息会指出检测到的搜索，并要求 Agent 单独重试非搜索操作。
 
 本地搜索在你的机器上进行。请只允许 Agent 读取已获授权的文件。HTTP 服务对外开放前需要认证网关，详见[安全说明](SECURITY.md)。
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer_signal_grep",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Context-efficient local search for files, documents, notes and logs across Pi, OMP and MCP clients",
   "keywords": [
     "ai-agent",

--- a/plugins/baoer-signal-grep/.claude-plugin/plugin.json
+++ b/plugins/baoer-signal-grep/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer-signal-grep",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Require baoer_signal_grep for conventional local searches while keeping development tools available.",
   "author": {
     "name": "宝儿"

--- a/plugins/baoer-signal-grep/.codex-plugin/plugin.json
+++ b/plugins/baoer-signal-grep/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer-signal-grep",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Require baoer_signal_grep for conventional local searches while keeping development tools available.",
   "author": {
     "name": "宝儿"

--- a/plugins/baoer-signal-grep/hooks/search-policy.mjs
+++ b/plugins/baoer-signal-grep/hooks/search-policy.mjs
@@ -3314,12 +3314,12 @@ function classifyCommand(argv, language, depth = 0) {
   if (args2.length === 1 && (args2[0] === "--help" || args2[0] === "--version"))
     return {};
   if (contentCommands.has(name2))
-    return { kind: "content" };
+    return { kind: "content", command: name2 };
   if (fileCommands.has(name2))
-    return { kind: "files" };
+    return { kind: "files", command: name2 };
   if (language === "powershell") {
     if (name2 === "select-string" || name2 === "sls")
-      return { kind: "content" };
+      return { kind: "content", command: name2 };
     if (["get-childitem", "gci", "dir", "ls"].includes(name2) && args2.some((arg, index) => {
       if (arg === null)
         return false;
@@ -3329,10 +3329,10 @@ function classifyCommand(argv, language, depth = 0) {
         return false;
       return /[*?[]/u.test(arg);
     }))
-      return { kind: "files" };
+      return { kind: "files", command: name2 };
   }
   if (name2 === "git") {
-    return args2[afterOptions(args2, gitValueOptions)] === "grep" ? { kind: "content" } : {};
+    return args2[afterOptions(args2, gitValueOptions)] === "grep" ? { kind: "content", command: "git grep" } : {};
   }
   if (["bash", "sh", "zsh", "dash", "ksh"].includes(name2)) {
     const index = args2.findIndex((arg) => arg !== null && /^-[a-z]*c[a-z]*$/u.test(arg));
@@ -3449,9 +3449,9 @@ class ShellSearchPolicy {
     ]);
     if (!bash || !powershell)
       throw new Error("Search policy grammar initialization failed");
-    return this.#inspect(command, language, { bash, powershell }, 0);
+    return this.#inspect(command, language, { bash, powershell }, 0, { nextCommandIndex: 1 });
   }
-  #inspect(command, language, grammars, depth) {
+  #inspect(command, language, grammars, depth, state) {
     if (depth > MAX_SHELL_NESTING)
       throw new Error("Search policy shell nesting exceeds 4 levels; simplify the command");
     const parser = new Parser;
@@ -3468,12 +3468,22 @@ class ShellSearchPolicy {
         for (const node of commands) {
           if (!node)
             continue;
+          const commandIndex = state.nextCommandIndex;
+          state.nextCommandIndex += 1;
           const words = commandWords(node, language);
           const decision = classifyCommand(words, language);
           if (decision.kind && !(decision.kind === "content" && isSafePipelineFilter(node, language, words)))
-            return decision.kind;
+            return {
+              kind: decision.kind,
+              command: decision.command ?? "search command",
+              commandIndex,
+              startByte: node.startIndex,
+              endByte: node.endIndex,
+              nestedDepth: depth,
+              language
+            };
           if (decision.nested) {
-            const nested = this.#inspect(decision.nested.command, decision.nested.language, grammars, depth + 1);
+            const nested = this.#inspect(decision.nested.command, decision.nested.language, grammars, depth + 1, state);
             if (nested)
               return nested;
           }
@@ -3505,11 +3515,21 @@ var shellTools = new Set([
 function isInputRecord(input) {
   return typeof input === "object" && input !== null && !Array.isArray(input);
 }
-function blocked(kind) {
-  const request = kind === "files" ? '{"mode":"files","query":"<filename or path>","path":"<scope>"}' : '{"pattern":"<search text>","path":"<scope>","scope":"strict"}';
+function recovery(kind) {
+  return kind === "files" ? '{"mode":"files","query":"<filename or path>","path":"<scope>"}' : '{"pattern":"<search text>","path":"<scope>","scope":"strict"}';
+}
+function blockedMatch(match) {
+  const location = match.nestedDepth > 0 ? `nested ${match.language} command #${match.commandIndex}` : `${match.language} subcommand #${match.commandIndex}`;
+  const request = recovery(match.kind);
   return {
     block: true,
-    reason: `baoer_signal_grep search policy: the entire tool call was denied before execution; none of its commands or operations ran. Call the available baoer_signal_grep tool (possibly MCP-prefixed) with ${request}. Do not repeat the blocked call. If the plugin is unavailable, report the connection error instead of bypassing the policy.`
+    reason: `baoer_signal_grep search policy blocked ${location} (${match.command} …, bytes ${match.startByte}-${match.endByte}) as a direct ${match.kind} search. The host shell call is atomic: the entire tool call was denied before execution, so none of its commands or operations ran. Split non-search operations into a separate shell call, then route only the detected search through the available baoer_signal_grep tool (possibly MCP-prefixed) with ${request}. Do not repeat the blocked search through another shell or custom script. If the plugin is unavailable, report the connection error instead of bypassing the policy.`
+  };
+}
+function blockedTool(kind, toolName) {
+  return {
+    block: true,
+    reason: `baoer_signal_grep search policy blocked direct ${kind} tool ${toolName}. The entire tool call was denied before execution. Route the search through the available baoer_signal_grep tool (possibly MCP-prefixed) with ${recovery(kind)}. If the plugin is unavailable, report the connection error instead of bypassing the policy.`
   };
 }
 
@@ -3521,9 +3541,9 @@ class SearchPolicy {
   async check(toolName, input, signal) {
     signal?.throwIfAborted();
     if (contentTools.has(toolName))
-      return blocked("content");
+      return blockedTool("content", toolName);
     if (fileTools.has(toolName))
-      return blocked("files");
+      return blockedTool("files", toolName);
     if (!shellTools.has(toolName))
       return;
     if (!isInputRecord(input))
@@ -3534,10 +3554,26 @@ class SearchPolicy {
       throw new Error("Search policy expected a shell command string");
     const shell = typeof fields.shell === "string" ? fields.shell : "";
     const language = /powershell|pwsh/iu.test(`${toolName} ${shell}`) || process.platform === "win32" && toolName !== "bash" ? "powershell" : "bash";
-    const kind = await this.#shell.inspect(command, language);
+    const match = await this.#shell.inspect(command, language);
     signal?.throwIfAborted();
-    return kind ? blocked(kind) : undefined;
+    return match ? blockedMatch(match) : undefined;
   }
+}
+
+// src/config-reader.ts
+var SIGNAL_GREP_ENFORCEMENT_ENV = "BAOER_SIGNAL_GREP_ENFORCE_SEARCH";
+function normalizeSearchEnforcement(value, source) {
+  if (value === undefined || value === true || value === "hard")
+    return "hard";
+  if (value === "prefer")
+    return "prefer";
+  if (value === false || value === "off")
+    return "off";
+  throw new Error(`Invalid baoer_signal_grep ${source}: enforceSearch must be true, false, "hard", "prefer", or "off"`);
+}
+function readNativeSearchEnforcement(environment = process.env) {
+  const value = environment[SIGNAL_GREP_ENFORCEMENT_ENV];
+  return normalizeSearchEnforcement(value, `environment variable ${SIGNAL_GREP_ENFORCEMENT_ENV}`);
 }
 
 // src/search-policy-hook.ts
@@ -3566,12 +3602,13 @@ var inputTimer = setTimeout(() => {
 try {
   const input = await hookInput();
   clearTimeout(inputTimer);
+  const enforcement = readNativeSearchEnforcement();
   if (typeof input !== "object" || input === null || !("hook_event_name" in input) || input.hook_event_name !== "PreToolUse" || !("tool_name" in input) || typeof input.tool_name !== "string" || !("tool_input" in input))
     throw new Error("Search policy received an invalid PreToolUse payload");
-  const decision = await new SearchPolicy(new URL("./", import.meta.url)).check(input.tool_name, input.tool_input);
+  const decision = enforcement === "hard" ? await new SearchPolicy(new URL("./", import.meta.url)).check(input.tool_name, input.tool_input) : undefined;
   if (decision)
     deny(decision.reason);
 } catch (error) {
   clearTimeout(inputTimer);
-  deny(error instanceof Error && error.message.startsWith("Search policy") ? error.message : "baoer_signal_grep search policy failed; repair or disable this plugin before retrying");
+  deny(error instanceof Error && (error.message.startsWith("Search policy") || error.message.startsWith("Invalid baoer_signal_grep environment variable")) ? error.message : "baoer_signal_grep search policy failed; repair or disable this plugin before retrying");
 }

--- a/plugins/baoer-signal-grep/kimi.plugin.json
+++ b/plugins/baoer-signal-grep/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer-signal-grep",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Require baoer_signal_grep for conventional local searches while keeping development tools available.",
   "author": {
     "name": "宝儿"

--- a/plugins/baoer-signal-grep/omp-extension.mjs
+++ b/plugins/baoer-signal-grep/omp-extension.mjs
@@ -45,7 +45,7 @@ import { readFile } from "fs/promises";
 var SIGNAL_GREP_CONFIG_FILE = "baoer_signal_grep.json";
 var DEFAULT_SIGNAL_GREP_CONFIG = {
   locale: "en",
-  enforceSearch: true
+  enforceSearch: "hard"
 };
 function hasErrorCode(error, codes) {
   return error instanceof Error && "code" in error && codes.includes(String(error.code));
@@ -64,12 +64,20 @@ function parseConfig(value, path) {
   if (locale !== undefined && locale !== "en" && locale !== "zh-CN") {
     throw new Error(`Invalid baoer_signal_grep config at ${path}: locale must be "en" or "zh-CN"`);
   }
-  if (enforceSearch !== undefined && typeof enforceSearch !== "boolean")
-    throw new Error(`Invalid baoer_signal_grep config at ${path}: enforceSearch must be boolean`);
+  const enforcement = normalizeSearchEnforcement(enforceSearch, `config at ${path}`);
   return {
     locale: locale ?? DEFAULT_SIGNAL_GREP_CONFIG.locale,
-    enforceSearch: enforceSearch ?? true
+    enforceSearch: enforcement
   };
+}
+function normalizeSearchEnforcement(value, source) {
+  if (value === undefined || value === true || value === "hard")
+    return "hard";
+  if (value === "prefer")
+    return "prefer";
+  if (value === false || value === "off")
+    return "off";
+  throw new Error(`Invalid baoer_signal_grep ${source}: enforceSearch must be true, false, "hard", "prefer", or "off"`);
 }
 async function readSignalGrepConfigFile(path) {
   try {
@@ -21337,12 +21345,12 @@ function classifyCommand(argv, language, depth = 0) {
   if (args2.length === 1 && (args2[0] === "--help" || args2[0] === "--version"))
     return {};
   if (contentCommands.has(name2))
-    return { kind: "content" };
+    return { kind: "content", command: name2 };
   if (fileCommands.has(name2))
-    return { kind: "files" };
+    return { kind: "files", command: name2 };
   if (language === "powershell") {
     if (name2 === "select-string" || name2 === "sls")
-      return { kind: "content" };
+      return { kind: "content", command: name2 };
     if (["get-childitem", "gci", "dir", "ls"].includes(name2) && args2.some((arg, index) => {
       if (arg === null)
         return false;
@@ -21352,10 +21360,10 @@ function classifyCommand(argv, language, depth = 0) {
         return false;
       return /[*?[]/u.test(arg);
     }))
-      return { kind: "files" };
+      return { kind: "files", command: name2 };
   }
   if (name2 === "git") {
-    return args2[afterOptions(args2, gitValueOptions)] === "grep" ? { kind: "content" } : {};
+    return args2[afterOptions(args2, gitValueOptions)] === "grep" ? { kind: "content", command: "git grep" } : {};
   }
   if (["bash", "sh", "zsh", "dash", "ksh"].includes(name2)) {
     const index = args2.findIndex((arg) => arg !== null && /^-[a-z]*c[a-z]*$/u.test(arg));
@@ -21472,9 +21480,9 @@ class ShellSearchPolicy {
     ]);
     if (!bash || !powershell)
       throw new Error("Search policy grammar initialization failed");
-    return this.#inspect(command, language, { bash, powershell }, 0);
+    return this.#inspect(command, language, { bash, powershell }, 0, { nextCommandIndex: 1 });
   }
-  #inspect(command, language, grammars, depth) {
+  #inspect(command, language, grammars, depth, state) {
     if (depth > MAX_SHELL_NESTING)
       throw new Error("Search policy shell nesting exceeds 4 levels; simplify the command");
     const parser = new Parser;
@@ -21491,12 +21499,22 @@ class ShellSearchPolicy {
         for (const node of commands) {
           if (!node)
             continue;
+          const commandIndex = state.nextCommandIndex;
+          state.nextCommandIndex += 1;
           const words = commandWords(node, language);
           const decision = classifyCommand(words, language);
           if (decision.kind && !(decision.kind === "content" && isSafePipelineFilter(node, language, words)))
-            return decision.kind;
+            return {
+              kind: decision.kind,
+              command: decision.command ?? "search command",
+              commandIndex,
+              startByte: node.startIndex,
+              endByte: node.endIndex,
+              nestedDepth: depth,
+              language
+            };
           if (decision.nested) {
-            const nested = this.#inspect(decision.nested.command, decision.nested.language, grammars, depth + 1);
+            const nested = this.#inspect(decision.nested.command, decision.nested.language, grammars, depth + 1, state);
             if (nested)
               return nested;
           }
@@ -21514,6 +21532,7 @@ class ShellSearchPolicy {
 // src/search-policy.ts
 var SEARCH_POLICY_GUIDANCE = "Local content and filename searches must use baoer_signal_grep. Built-in search tools and direct search commands are blocked before execution; filtering output from an unrelated producer at a pipeline tail remains available. Use pattern for contents or mode=files with query for filenames. Keep read/edit/write, tests and builds available. Do not retry a blocked search through another shell or a custom script.";
 var PI_REPLACED_SEARCH_TOOLS = new Set(["grep", "find"]);
+var PREFERRED_SEARCH_GUIDANCE = "Prefer baoer_signal_grep for local content and filename searches because it provides bounded evidence, coverage and continuation details. Conventional search entries remain available in advisory mode.";
 var contentTools = new Set(["grep", "Grep", "SearchFileContent"]);
 var fileTools = new Set(["find", "glob", "Glob", "GlobFile", "SearchFiles"]);
 var shellTools = new Set([
@@ -21529,11 +21548,21 @@ var shellTools = new Set([
 function isInputRecord(input) {
   return typeof input === "object" && input !== null && !Array.isArray(input);
 }
-function blocked(kind) {
-  const request = kind === "files" ? '{"mode":"files","query":"<filename or path>","path":"<scope>"}' : '{"pattern":"<search text>","path":"<scope>","scope":"strict"}';
+function recovery(kind) {
+  return kind === "files" ? '{"mode":"files","query":"<filename or path>","path":"<scope>"}' : '{"pattern":"<search text>","path":"<scope>","scope":"strict"}';
+}
+function blockedMatch(match) {
+  const location = match.nestedDepth > 0 ? `nested ${match.language} command #${match.commandIndex}` : `${match.language} subcommand #${match.commandIndex}`;
+  const request = recovery(match.kind);
   return {
     block: true,
-    reason: `baoer_signal_grep search policy: the entire tool call was denied before execution; none of its commands or operations ran. Call the available baoer_signal_grep tool (possibly MCP-prefixed) with ${request}. Do not repeat the blocked call. If the plugin is unavailable, report the connection error instead of bypassing the policy.`
+    reason: `baoer_signal_grep search policy blocked ${location} (${match.command} \u2026, bytes ${match.startByte}-${match.endByte}) as a direct ${match.kind} search. The host shell call is atomic: the entire tool call was denied before execution, so none of its commands or operations ran. Split non-search operations into a separate shell call, then route only the detected search through the available baoer_signal_grep tool (possibly MCP-prefixed) with ${request}. Do not repeat the blocked search through another shell or custom script. If the plugin is unavailable, report the connection error instead of bypassing the policy.`
+  };
+}
+function blockedTool(kind, toolName) {
+  return {
+    block: true,
+    reason: `baoer_signal_grep search policy blocked direct ${kind} tool ${toolName}. The entire tool call was denied before execution. Route the search through the available baoer_signal_grep tool (possibly MCP-prefixed) with ${recovery(kind)}. If the plugin is unavailable, report the connection error instead of bypassing the policy.`
   };
 }
 
@@ -21545,9 +21574,9 @@ class SearchPolicy {
   async check(toolName, input, signal) {
     signal?.throwIfAborted();
     if (contentTools.has(toolName))
-      return blocked("content");
+      return blockedTool("content", toolName);
     if (fileTools.has(toolName))
-      return blocked("files");
+      return blockedTool("files", toolName);
     if (!shellTools.has(toolName))
       return;
     if (!isInputRecord(input))
@@ -21558,9 +21587,9 @@ class SearchPolicy {
       throw new Error("Search policy expected a shell command string");
     const shell = typeof fields.shell === "string" ? fields.shell : "";
     const language = /powershell|pwsh/iu.test(`${toolName} ${shell}`) || process.platform === "win32" && toolName !== "bash" ? "powershell" : "bash";
-    const kind = await this.#shell.inspect(command, language);
+    const match = await this.#shell.inspect(command, language);
     signal?.throwIfAborted();
-    return kind ? blocked(kind) : undefined;
+    return match ? blockedMatch(match) : undefined;
   }
 }
 
@@ -26040,9 +26069,9 @@ function ompAgentDir() {
   const profile = ompProfile();
   return profile ? join5(homedir3(), configDir, "profiles", profile, "agent") : join5(homedir3(), configDir, "agent");
 }
-function selectSearchTools(pi) {
+function selectSearchTools(pi, replaceAlternatives) {
   const current = pi.getActiveTools();
-  const next = current.filter((tool) => !OMP_REPLACED_SEARCH_TOOLS.has(tool));
+  const next = replaceAlternatives ? current.filter((tool) => !OMP_REPLACED_SEARCH_TOOLS.has(tool)) : [...current];
   if (!next.includes(SIGNAL_GREP_LABEL))
     next.push(SIGNAL_GREP_LABEL);
   return next;
@@ -26061,10 +26090,11 @@ async function registerOmpSignalGrepExtension(pi, searchPolicyAssets = new URL("
   const policy = new SearchPolicy(searchPolicyAssets);
   const resolvedConfig = config ?? await readSignalGrepConfigFile(join5(ompAgentDir(), SIGNAL_GREP_CONFIG_FILE));
   const { locale: locale2 } = resolvedConfig;
+  const enforcement = normalizeSearchEnforcement(resolvedConfig.enforceSearch, "OMP extension config");
   let selection2 = Promise.resolve();
   const updateSelection = async () => {
     const current = pi.getActiveTools();
-    const next = selectSearchTools(pi);
+    const next = selectSearchTools(pi, enforcement === "hard");
     if (toolSelectionChanged(current, next))
       await pi.setActiveTools(next);
   };
@@ -26095,13 +26125,15 @@ async function registerOmpSignalGrepExtension(pi, searchPolicyAssets = new URL("
       };
     }
   });
-  if (resolvedConfig.enforceSearch !== false) {
+  if (enforcement !== "off") {
     pi.on("session_start", selectTools);
     pi.on("before_agent_start", async (event) => {
       await selectTools();
-      return { systemPrompt: [...event.systemPrompt, SEARCH_POLICY_GUIDANCE] };
+      const guidance = enforcement === "hard" ? SEARCH_POLICY_GUIDANCE : PREFERRED_SEARCH_GUIDANCE;
+      return { systemPrompt: [...event.systemPrompt, guidance] };
     });
-    pi.on("tool_call", (event) => policy.check(event.toolName, event.input));
+    if (enforcement === "hard")
+      pi.on("tool_call", (event) => policy.check(event.toolName, event.input));
   }
   pi.on("session_shutdown", async (_event, ctx) => {
     await runtime.shutdown();

--- a/plugins/baoer-signal-grep/package.json
+++ b/plugins/baoer-signal-grep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baoer-signal-grep",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "omp": {

--- a/src/config-reader.ts
+++ b/src/config-reader.ts
@@ -3,15 +3,19 @@ import { readFile } from "node:fs/promises";
 export const SIGNAL_GREP_CONFIG_FILE = "baoer_signal_grep.json";
 
 export type SignalGrepLocale = "en" | "zh-CN";
+export type SearchEnforcementMode = "hard" | "prefer" | "off";
+export type SearchEnforcementSetting = boolean | SearchEnforcementMode;
+
+export const SIGNAL_GREP_ENFORCEMENT_ENV = "BAOER_SIGNAL_GREP_ENFORCE_SEARCH";
 
 export interface SignalGrepConfig {
   locale: SignalGrepLocale;
-  enforceSearch?: boolean;
+  enforceSearch?: SearchEnforcementSetting;
 }
 
 export const DEFAULT_SIGNAL_GREP_CONFIG: Readonly<SignalGrepConfig> = {
   locale: "en",
-  enforceSearch: true,
+  enforceSearch: "hard",
 };
 
 interface RawSignalGrepConfig {
@@ -39,12 +43,28 @@ function parseConfig(value: unknown, path: string): SignalGrepConfig {
   if (locale !== undefined && locale !== "en" && locale !== "zh-CN") {
     throw new Error(`Invalid baoer_signal_grep config at ${path}: locale must be "en" or "zh-CN"`);
   }
-  if (enforceSearch !== undefined && typeof enforceSearch !== "boolean")
-    throw new Error(`Invalid baoer_signal_grep config at ${path}: enforceSearch must be boolean`);
+  const enforcement = normalizeSearchEnforcement(enforceSearch, `config at ${path}`);
   return {
     locale: locale ?? DEFAULT_SIGNAL_GREP_CONFIG.locale,
-    enforceSearch: enforceSearch ?? true,
+    enforceSearch: enforcement,
   };
+}
+
+export function normalizeSearchEnforcement(value: unknown, source: string): SearchEnforcementMode {
+  if (value === undefined || value === true || value === "hard") return "hard";
+  if (value === "prefer") return "prefer";
+  if (value === false || value === "off") return "off";
+  throw new Error(
+    `Invalid baoer_signal_grep ${source}: enforceSearch must be true, false, "hard", "prefer", or "off"`,
+  );
+}
+
+/** Native hooks inherit this setting from their host process; absent means fail-safe hard mode. */
+export function readNativeSearchEnforcement(
+  environment: NodeJS.ProcessEnv = process.env,
+): SearchEnforcementMode {
+  const value = environment[SIGNAL_GREP_ENFORCEMENT_ENV];
+  return normalizeSearchEnforcement(value, `environment variable ${SIGNAL_GREP_ENFORCEMENT_ENV}`);
 }
 
 /** Read and validate one host-selected config path. */

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,8 +8,10 @@ import {
 
 export {
   DEFAULT_SIGNAL_GREP_CONFIG,
+  normalizeSearchEnforcement,
   type SignalGrepConfig,
   type SignalGrepLocale,
+  type SearchEnforcementMode,
 } from "./config-reader.js";
 
 export function signalGrepConfigPath(agentDir = getAgentDir()): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 import { SIGNAL_GREP_DESCRIPTION, signalGrepSchema } from "./tool-schema.js";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { readSignalGrepConfig, type SignalGrepConfig } from "./config.js";
+import {
+  normalizeSearchEnforcement,
+  readSignalGrepConfig,
+  type SignalGrepConfig,
+} from "./config.js";
 import { resolveContextBudget } from "./context-budget.js";
 import { createRipgrepRunner } from "./rg.js";
 import { createCtagsStructureProvider } from "./structure.js";
@@ -65,7 +69,8 @@ export async function registerSignalGrepExtension(
     },
   });
 
-  if (config.enforceSearch !== false) registerPiSearchPolicy(pi);
+  const enforcement = normalizeSearchEnforcement(config.enforceSearch, "extension config");
+  if (enforcement !== "off") registerPiSearchPolicy(pi, enforcement);
 
   pi.on("session_shutdown", async (_event, ctx) => {
     await runtime.shutdown();

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -9,7 +9,7 @@ import { URL as URL2 } from "node:url";
 // package.json
 var package_default = {
   name: "baoer_signal_grep",
-  version: "1.3.2",
+  version: "1.4.0",
   description: "Context-efficient local search for files, documents, notes and logs across Pi, OMP and MCP clients",
   keywords: [
     "ai-agent",

--- a/src/omp-index.ts
+++ b/src/omp-index.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 import {
+  normalizeSearchEnforcement,
   readSignalGrepConfigFile,
   SIGNAL_GREP_CONFIG_FILE,
   type SignalGrepConfig,
@@ -17,7 +18,11 @@ import {
   renderSignalGrepResult,
   type SignalGrepToolResult,
 } from "./tui/renderers.js";
-import { SEARCH_POLICY_GUIDANCE, SearchPolicy } from "./search-policy.js";
+import {
+  PREFERRED_SEARCH_GUIDANCE,
+  SEARCH_POLICY_GUIDANCE,
+  SearchPolicy,
+} from "./search-policy.js";
 import { signalGrepSchema } from "./tool-schema.js";
 
 const SIGNAL_GREP_LABEL = "baoer_signal_grep";
@@ -140,9 +145,11 @@ function ompAgentDir(): string {
     : join(homedir(), configDir, "agent");
 }
 
-function selectSearchTools(pi: OmpExtensionAPI): string[] {
+function selectSearchTools(pi: OmpExtensionAPI, replaceAlternatives: boolean): string[] {
   const current = pi.getActiveTools();
-  const next = current.filter((tool) => !OMP_REPLACED_SEARCH_TOOLS.has(tool));
+  const next = replaceAlternatives
+    ? current.filter((tool) => !OMP_REPLACED_SEARCH_TOOLS.has(tool))
+    : [...current];
   if (!next.includes(SIGNAL_GREP_LABEL)) next.push(SIGNAL_GREP_LABEL);
   return next;
 }
@@ -173,10 +180,14 @@ export async function registerOmpSignalGrepExtension(
   const resolvedConfig =
     config ?? (await readSignalGrepConfigFile(join(ompAgentDir(), SIGNAL_GREP_CONFIG_FILE)));
   const { locale } = resolvedConfig;
+  const enforcement = normalizeSearchEnforcement(
+    resolvedConfig.enforceSearch,
+    "OMP extension config",
+  );
   let selection = Promise.resolve();
   const updateSelection = async (): Promise<void> => {
     const current = pi.getActiveTools();
-    const next = selectSearchTools(pi);
+    const next = selectSearchTools(pi, enforcement === "hard");
     if (toolSelectionChanged(current, next)) await pi.setActiveTools(next);
   };
   const selectTools = (): Promise<void> => {
@@ -217,13 +228,15 @@ export async function registerOmpSignalGrepExtension(
     },
   });
 
-  if (resolvedConfig.enforceSearch !== false) {
+  if (enforcement !== "off") {
     pi.on("session_start", selectTools);
     pi.on("before_agent_start", async (event) => {
       await selectTools();
-      return { systemPrompt: [...event.systemPrompt, SEARCH_POLICY_GUIDANCE] };
+      const guidance = enforcement === "hard" ? SEARCH_POLICY_GUIDANCE : PREFERRED_SEARCH_GUIDANCE;
+      return { systemPrompt: [...event.systemPrompt, guidance] };
     });
-    pi.on("tool_call", (event) => policy.check(event.toolName, event.input));
+    if (enforcement === "hard")
+      pi.on("tool_call", (event) => policy.check(event.toolName, event.input));
   }
 
   pi.on("session_shutdown", async (_event, ctx) => {

--- a/src/pi-search-policy.ts
+++ b/src/pi-search-policy.ts
@@ -1,11 +1,23 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { PI_REPLACED_SEARCH_TOOLS, SEARCH_POLICY_GUIDANCE, SearchPolicy } from "./search-policy.js";
+import type { SearchEnforcementMode } from "./config-reader.js";
+import {
+  PI_REPLACED_SEARCH_TOOLS,
+  PREFERRED_SEARCH_GUIDANCE,
+  SEARCH_POLICY_GUIDANCE,
+  SearchPolicy,
+} from "./search-policy.js";
 
-export function registerPiSearchPolicy(pi: ExtensionAPI): void {
+export function registerPiSearchPolicy(
+  pi: ExtensionAPI,
+  mode: Exclude<SearchEnforcementMode, "off">,
+): void {
   const policy = new SearchPolicy(new URL("../plugins/baoer-signal-grep/hooks/", import.meta.url));
   const selectTools = () => {
     const current = pi.getActiveTools();
-    const next = current.filter((tool) => !PI_REPLACED_SEARCH_TOOLS.has(tool));
+    const next =
+      mode === "hard"
+        ? current.filter((tool) => !PI_REPLACED_SEARCH_TOOLS.has(tool))
+        : [...current];
     if (!next.includes("baoer_signal_grep")) next.push("baoer_signal_grep");
     if (next.length !== current.length || next.some((tool, index) => tool !== current[index]))
       pi.setActiveTools(next);
@@ -13,7 +25,9 @@ export function registerPiSearchPolicy(pi: ExtensionAPI): void {
   pi.on("session_start", selectTools);
   pi.on("before_agent_start", (event) => {
     selectTools();
-    return { systemPrompt: `${event.systemPrompt}\n\n${SEARCH_POLICY_GUIDANCE}` };
+    const guidance = mode === "hard" ? SEARCH_POLICY_GUIDANCE : PREFERRED_SEARCH_GUIDANCE;
+    return { systemPrompt: `${event.systemPrompt}\n\n${guidance}` };
   });
-  pi.on("tool_call", async (event, ctx) => policy.check(event.toolName, event.input, ctx.signal));
+  if (mode === "hard")
+    pi.on("tool_call", async (event, ctx) => policy.check(event.toolName, event.input, ctx.signal));
 }

--- a/src/search-policy-commands.ts
+++ b/src/search-policy-commands.ts
@@ -3,6 +3,7 @@ export type ShellLanguage = "bash" | "powershell";
 
 export interface CommandDecision {
   kind?: SearchKind;
+  command?: string;
   nested?: { command: string; language: ShellLanguage };
 }
 
@@ -110,10 +111,10 @@ export function classifyCommand(
   const name = language === "powershell" ? rawName.toLowerCase() : rawName;
   const args = argv.slice(1);
   if (args.length === 1 && (args[0] === "--help" || args[0] === "--version")) return {};
-  if (contentCommands.has(name)) return { kind: "content" };
-  if (fileCommands.has(name)) return { kind: "files" };
+  if (contentCommands.has(name)) return { kind: "content", command: name };
+  if (fileCommands.has(name)) return { kind: "files", command: name };
   if (language === "powershell") {
-    if (name === "select-string" || name === "sls") return { kind: "content" };
+    if (name === "select-string" || name === "sls") return { kind: "content", command: name };
     if (
       ["get-childitem", "gci", "dir", "ls"].includes(name) &&
       args.some((arg, index) => {
@@ -125,10 +126,12 @@ export function classifyCommand(
         return /[*?[]/u.test(arg);
       })
     )
-      return { kind: "files" };
+      return { kind: "files", command: name };
   }
   if (name === "git") {
-    return args[afterOptions(args, gitValueOptions)] === "grep" ? { kind: "content" } : {};
+    return args[afterOptions(args, gitValueOptions)] === "grep"
+      ? { kind: "content", command: "git grep" }
+      : {};
   }
   if (["bash", "sh", "zsh", "dash", "ksh"].includes(name)) {
     const index = args.findIndex((arg) => arg !== null && /^-[a-z]*c[a-z]*$/u.test(arg));

--- a/src/search-policy-hook.ts
+++ b/src/search-policy-hook.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { SearchPolicy } from "./search-policy.js";
+import { readNativeSearchEnforcement } from "./config-reader.js";
 
 const MAX_HOOK_INPUT_BYTES = 256 * 1024;
 
@@ -28,6 +29,7 @@ const inputTimer = setTimeout(() => {
 try {
   const input = await hookInput();
   clearTimeout(inputTimer);
+  const enforcement = readNativeSearchEnforcement();
   if (
     typeof input !== "object" ||
     input === null ||
@@ -38,16 +40,21 @@ try {
     !("tool_input" in input)
   )
     throw new Error("Search policy received an invalid PreToolUse payload");
-  const decision = await new SearchPolicy(new URL("./", import.meta.url)).check(
-    input.tool_name,
-    input.tool_input,
-  );
+  const decision =
+    enforcement === "hard"
+      ? await new SearchPolicy(new URL("./", import.meta.url)).check(
+          input.tool_name,
+          input.tool_input,
+        )
+      : undefined;
   if (decision) deny(decision.reason);
 } catch (error) {
   clearTimeout(inputTimer);
   // Do not echo command text, paths, or JSON parse errors that could contain credentials.
   deny(
-    error instanceof Error && error.message.startsWith("Search policy")
+    error instanceof Error &&
+      (error.message.startsWith("Search policy") ||
+        error.message.startsWith("Invalid baoer_signal_grep environment variable"))
       ? error.message
       : "baoer_signal_grep search policy failed; repair or disable this plugin before retrying",
   );

--- a/src/search-policy-shell.ts
+++ b/src/search-policy-shell.ts
@@ -10,6 +10,20 @@ import {
 export const MAX_POLICY_COMMAND_BYTES = 64 * 1024;
 const MAX_SHELL_NESTING = 4;
 
+export interface ShellSearchMatch {
+  kind: SearchKind;
+  command: string;
+  commandIndex: number;
+  startByte: number;
+  endByte: number;
+  nestedDepth: number;
+  language: ShellLanguage;
+}
+
+interface InspectionState {
+  nextCommandIndex: number;
+}
+
 function literalWord(node: Node, language: ShellLanguage): string | null {
   const text = node.text;
   if (language === "powershell") {
@@ -91,7 +105,7 @@ export class ShellSearchPolicy {
     this.#assets = assets;
   }
 
-  async inspect(command: string, language: ShellLanguage): Promise<SearchKind | undefined> {
+  async inspect(command: string, language: ShellLanguage): Promise<ShellSearchMatch | undefined> {
     if (Buffer.byteLength(command, "utf8") > MAX_POLICY_COMMAND_BYTES)
       throw new Error("Search policy command exceeds 64 KiB; split the shell request");
     this.#initialization ??= Parser.init({
@@ -111,7 +125,7 @@ export class ShellSearchPolicy {
       this.#languages.get("powershell"),
     ]);
     if (!bash || !powershell) throw new Error("Search policy grammar initialization failed");
-    return this.#inspect(command, language, { bash, powershell }, 0);
+    return this.#inspect(command, language, { bash, powershell }, 0, { nextCommandIndex: 1 });
   }
 
   #inspect(
@@ -119,7 +133,8 @@ export class ShellSearchPolicy {
     language: ShellLanguage,
     grammars: Record<ShellLanguage, Language>,
     depth: number,
-  ): SearchKind | undefined {
+    state: InspectionState,
+  ): ShellSearchMatch | undefined {
     if (depth > MAX_SHELL_NESTING)
       throw new Error("Search policy shell nesting exceeds 4 levels; simplify the command");
     const parser = new Parser();
@@ -135,19 +150,30 @@ export class ShellSearchPolicy {
         const commands = tree.rootNode.descendantsOfType("command");
         for (const node of commands) {
           if (!node) continue;
+          const commandIndex = state.nextCommandIndex;
+          state.nextCommandIndex += 1;
           const words = commandWords(node, language);
           const decision = classifyCommand(words, language);
           if (
             decision.kind &&
             !(decision.kind === "content" && isSafePipelineFilter(node, language, words))
           )
-            return decision.kind;
+            return {
+              kind: decision.kind,
+              command: decision.command ?? "search command",
+              commandIndex,
+              startByte: node.startIndex,
+              endByte: node.endIndex,
+              nestedDepth: depth,
+              language,
+            };
           if (decision.nested) {
             const nested = this.#inspect(
               decision.nested.command,
               decision.nested.language,
               grammars,
               depth + 1,
+              state,
             );
             if (nested) return nested;
           }

--- a/src/search-policy.ts
+++ b/src/search-policy.ts
@@ -1,9 +1,11 @@
 import type { SearchKind, ShellLanguage } from "./search-policy-commands.js";
-import { ShellSearchPolicy } from "./search-policy-shell.js";
+import { ShellSearchPolicy, type ShellSearchMatch } from "./search-policy-shell.js";
 
 export const SEARCH_POLICY_GUIDANCE =
   "Local content and filename searches must use baoer_signal_grep. Built-in search tools and direct search commands are blocked before execution; filtering output from an unrelated producer at a pipeline tail remains available. Use pattern for contents or mode=files with query for filenames. Keep read/edit/write, tests and builds available. Do not retry a blocked search through another shell or a custom script.";
 export const PI_REPLACED_SEARCH_TOOLS = new Set(["grep", "find"]);
+export const PREFERRED_SEARCH_GUIDANCE =
+  "Prefer baoer_signal_grep for local content and filename searches because it provides bounded evidence, coverage and continuation details. Conventional search entries remain available in advisory mode.";
 const contentTools = new Set(["grep", "Grep", "SearchFileContent"]);
 const fileTools = new Set(["find", "glob", "Glob", "GlobFile", "SearchFiles"]);
 const shellTools = new Set([
@@ -26,14 +28,28 @@ function isInputRecord(input: unknown): input is Record<string, unknown> {
   return typeof input === "object" && input !== null && !Array.isArray(input);
 }
 
-function blocked(kind: SearchKind): SearchPolicyDecision {
-  const request =
-    kind === "files"
-      ? '{"mode":"files","query":"<filename or path>","path":"<scope>"}'
-      : '{"pattern":"<search text>","path":"<scope>","scope":"strict"}';
+function recovery(kind: SearchKind): string {
+  return kind === "files"
+    ? '{"mode":"files","query":"<filename or path>","path":"<scope>"}'
+    : '{"pattern":"<search text>","path":"<scope>","scope":"strict"}';
+}
+
+function blockedMatch(match: ShellSearchMatch): SearchPolicyDecision {
+  const location =
+    match.nestedDepth > 0
+      ? `nested ${match.language} command #${match.commandIndex}`
+      : `${match.language} subcommand #${match.commandIndex}`;
+  const request = recovery(match.kind);
   return {
     block: true,
-    reason: `baoer_signal_grep search policy: the entire tool call was denied before execution; none of its commands or operations ran. Call the available baoer_signal_grep tool (possibly MCP-prefixed) with ${request}. Do not repeat the blocked call. If the plugin is unavailable, report the connection error instead of bypassing the policy.`,
+    reason: `baoer_signal_grep search policy blocked ${location} (${match.command} …, bytes ${match.startByte}-${match.endByte}) as a direct ${match.kind} search. The host shell call is atomic: the entire tool call was denied before execution, so none of its commands or operations ran. Split non-search operations into a separate shell call, then route only the detected search through the available baoer_signal_grep tool (possibly MCP-prefixed) with ${request}. Do not repeat the blocked search through another shell or custom script. If the plugin is unavailable, report the connection error instead of bypassing the policy.`,
+  };
+}
+
+function blockedTool(kind: SearchKind, toolName: string): SearchPolicyDecision {
+  return {
+    block: true,
+    reason: `baoer_signal_grep search policy blocked direct ${kind} tool ${toolName}. The entire tool call was denied before execution. Route the search through the available baoer_signal_grep tool (possibly MCP-prefixed) with ${recovery(kind)}. If the plugin is unavailable, report the connection error instead of bypassing the policy.`,
   };
 }
 
@@ -49,8 +65,8 @@ export class SearchPolicy {
     signal?: AbortSignal,
   ): Promise<SearchPolicyDecision | undefined> {
     signal?.throwIfAborted();
-    if (contentTools.has(toolName)) return blocked("content");
-    if (fileTools.has(toolName)) return blocked("files");
+    if (contentTools.has(toolName)) return blockedTool("content", toolName);
+    if (fileTools.has(toolName)) return blockedTool("files", toolName);
     if (!shellTools.has(toolName)) return undefined;
     if (!isInputRecord(input)) throw new Error("Search policy expected a tool input object");
     const fields = input;
@@ -63,8 +79,8 @@ export class SearchPolicy {
       (process.platform === "win32" && toolName !== "bash")
         ? "powershell"
         : "bash";
-    const kind = await this.#shell.inspect(command, language);
+    const match = await this.#shell.inspect(command, language);
     signal?.throwIfAborted();
-    return kind ? blocked(kind) : undefined;
+    return match ? blockedMatch(match) : undefined;
   }
 }


### PR DESCRIPTION
## Change

Closes #62.

Strict search enforcement now identifies the triggering Bash or PowerShell subcommand, its sequence and bounded source position, explains atomic host-call denial, and gives a targeted split-and-retry recovery path without exposing search arguments.

Search enforcement now supports normalized hard, prefer and off modes while retaining boolean compatibility. Hard remains the default and preserves the existing allow/deny matrix. Prefer keeps baoer_signal_grep plus competing tools and model guidance without denial. Native Claude Code, Codex and Kimi hooks accept BAOER_SIGNAL_GREP_ENFORCE_SEARCH=hard|prefer|off and reject invalid values fail-closed.

The package version is 1.4.0 and all generated native/MCP artifacts were rebuilt.

## Validation

- [x] bun run check
- [x] bun run check:local (374 passed, 1 optional offline model test skipped, 0 failed)
- [x] bun run pack:check
- [x] bun run test:mcp-hosts (Claude Code, Codex and Kimi Code passed)
- [x] 17-case isolated tmp native-hook matrix; fixture removed
- [x] 24-case 1.3.2-vs-1.4.0 hard-mode differential parity; fixture removed
- [x] Reviewed the final diff and shipped artifacts

## Compatibility and risks

Unconfigured and true enforcement remain hard. false remains compatible and normalizes to off. Refusal text intentionally becomes more precise, while allow/deny decisions and atomic non-execution remain unchanged. Command diagnostics expose only the classified command identity and positions, never its arguments. Prefer mode is explicit and does not weaken the default.

## Documentation

- [x] Updated English and Simplified Chinese configuration, native-host and pipeline behavior
- [x] No private source, tests, internal documents, credentials or logs are included

## AI assistance

Implemented and reviewed by OpenAI Codex (GPT-5 family). The AI executed all validation listed above. No human review has yet been recorded.